### PR TITLE
Bugs/metadata values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Added show/hide all sub-techniques controls under "layer controls". See issue [#141](https://github.com/mitre-attack/attack-navigator/issues/141)
 ## Fixes
 - Added internet explorer support for the sub-techniques features, and improved Edge compatibility. See issue [#135](https://github.com/mitre-attack/attack-navigator/issues/135).
+- Fixed a bug causing metadata values to be displayed improperly in tooltips. See issue [#153](https://github.com/mitre-attack/attack-navigator/issues/153).
 
 
 # v3.0 - sub-techniques beta

--- a/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.html
+++ b/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.html
@@ -19,7 +19,7 @@
         </tr>
         <tr *ngFor="let metadata of techniqueVM.metadata">
             <td>{{metadata.name}}:</td>
-            <td>{{metadata.value</td>
+            <td>{{metadata.value}}</td>
         </tr>
     </table>
 </div>


### PR DESCRIPTION
Fixes the typo in the tooltip component causing metadata values to be displayed improperly on the Navigator.

Resolves issue #153 