### PR TITLE
Fix for layer URL inputs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 
 ## Fixes
 - Added internet explorer support for the sub-techniques features, and improved Edge compatibility. See issue [#135](https://github.com/mitre-attack/attack-navigator/issues/135).
-- Fixed a bug causing metadata values to be displayed improperly in tooltips. See issue [#153](https://github.com/mitre-attack/attack-navigator/issues/153).
+- Fixes a bug causing metadata values to be displayed improperly in tooltips. See issue [#153](https://github.com/mitre-attack/attack-navigator/issues/153).
+- Fixes a bug in which the default layer link input field in the "create customized Navigator" interface loses focus between characters. See issue [#136](https://github.com/mitre-attack/attack-navigator/issues/136).
 
 
 # v3.0 - sub-techniques beta

--- a/nav-app/src/app/tabs/tabs.component.html
+++ b/nav-app/src/app/tabs/tabs.component.html
@@ -222,12 +222,10 @@
                     <tr class="custom_nav_inputsection">
                         <td>
                             <ul class="layerLinks">
-                                <li *ngFor="let layerLinkURL of layerLinkURLs; let i = index">
+                                <li *ngFor="let layerLinkURL of layerLinkURLs; let i = index trackBy:trackByFunction">
                                     <mat-form-field>
-                                        <input type="text"
-                                        matInput
-                                        [placeholder]="'default layer URL ' + (i + 1)"
-                                        [(ngModel)]="layerLinkURLs[i]"/>
+                                        <input type="text" matInput
+                                            [placeholder]="'default layer URL ' + (i + 1)" [(ngModel)]="layerLinkURLs[i]"/>
                                         <button mat-button matSuffix mat-icon-button aria-label="remove" (click)="removeLayerLink(i)">
                                             x
                                         </button>

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -11,7 +11,7 @@ import { DataTableComponent} from '../datatable/data-table.component';
 import { ViewModelsService, ViewModel, TechniqueVM, Gradient, Gcolor } from "../viewmodels.service";
 
 import {ErrorStateMatcher} from '@angular/material/core'
-import {FormControl, FormArray} from '@angular/forms';
+import {FormControl} from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import * as globals from './../globals';
 import { log } from 'util';
@@ -525,6 +525,9 @@ export class TabsComponent implements AfterContentInit {
     layerLinkURLs: string[] = [];
     customizedConfig = [];
 
+    /**
+     * Helper function to track which layerLinkURLs have been added or removed
+     */
     trackByFunction(index: number, obj: any): any {
         return index;
     }

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -11,7 +11,7 @@ import { DataTableComponent} from '../datatable/data-table.component';
 import { ViewModelsService, ViewModel, TechniqueVM, Gradient, Gcolor } from "../viewmodels.service";
 
 import {ErrorStateMatcher} from '@angular/material/core'
-import {FormControl} from '@angular/forms';
+import {FormControl, FormArray} from '@angular/forms';
 import { HttpClient } from '@angular/common/http';
 import * as globals from './../globals';
 import { log } from 'util';
@@ -524,6 +524,10 @@ export class TabsComponent implements AfterContentInit {
     // layerLinkURL = ""; //the user inputted layer link which will get parsed into a param
     layerLinkURLs: string[] = [];
     customizedConfig = [];
+
+    trackByFunction(index: number, obj: any): any {
+        return index;
+    }
 
     /**
      * Add a new empty layer link to the layerLinkURLs array


### PR DESCRIPTION
Fixes the bug in the "create customized Navigator" interface in which the layer URL input field loses focus after each typed character and appends the character to subsequent URLs.

Resolves Issue #136 