### PR TITLE
Bug fixes for multiselect interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Fixes a bug in which the default layer link input field in the "create customized Navigator" interface loses focus between characters. See issue [#136](https://github.com/mitre-attack/attack-navigator/issues/136).
 - Fixed a bug in "create layer from other layers" interface where inheriting filters would cause the application to crash. See issue [#168](https://github.com/mitre-attack/attack-navigator/issues/168).
 - Fixed a bug where editing the gradient would also change the most recently selected gradient preset. See issue [#167](https://github.com/mitre-attack/attack-navigator/issues/167).
+- Removed duplicate threat group entries from the multiselect interface and included sub-techniques in the selection of techniques related to threat groups, software, or mitigations. See issue [#164](https://github.com/mitre-attack/attack-navigator/issues/164).
 
 
 # v3.0 - sub-techniques beta

--- a/nav-app/src/app/data.service.ts
+++ b/nav-app/src/app/data.service.ts
@@ -36,6 +36,7 @@ export class DataService {
     public matrices: Matrix[] = [];
     public tactics: Tactic[] = [];
     public techniques: Technique[] = [];
+    public subtechniques: Technique[] = [];
     public software: Software[] = [];
     public groups: Group[] = [];
     public mitigations: Mitigation[] = [];
@@ -73,7 +74,6 @@ export class DataService {
     parseBundle(stixBundle: any[]): void {
         let techniqueSDOs = [];
         let idToTechniqueSDO = new Map<string, any>();
-        let subtechniqueSDOs = [];
         let matrixSDOs = [];
 
         let idToTacticSDO = new Map<string, any>();
@@ -138,7 +138,9 @@ export class DataService {
                     case "attack-pattern":
                         idToTechniqueSDO.set(sdo.id, sdo);
                         if (sdo.x_mitre_is_subtechnique) {
-                            if (this.subtechniquesEnabled) subtechniqueSDOs.push(sdo);
+                            if (this.subtechniquesEnabled) {
+                                this.subtechniques.push(new Technique(sdo, [], this));
+                            }
                         } else techniqueSDOs.push(sdo);
                         break;
                     case "x-mitre-tactic":

--- a/nav-app/src/app/multiselect/multiselect.component.ts
+++ b/nav-app/src/app/multiselect/multiselect.component.ts
@@ -31,12 +31,15 @@ export class MultiselectComponent implements OnInit {
     ngOnInit() {}
 
     private getRelated(stixObject: BaseStix): Technique[] {
+        // master list of all techniques and sub-techniques
+        let allTechniques = this.dataService.techniques.concat(this.dataService.subtechniques);
+
         if (stixObject instanceof Group) {
-            return this.dataService.techniques.filter((technique: Technique) => (stixObject as Group).relatedTechniques().includes(technique.id));
+            return allTechniques.filter((technique: Technique) => (stixObject as Group).relatedTechniques().includes(technique.id));
         } else if (stixObject instanceof Software) {
-            return this.dataService.techniques.filter((technique: Technique) => (stixObject as Software).relatedTechniques().includes(technique.id));
+            return allTechniques.filter((technique: Technique) => (stixObject as Software).relatedTechniques().includes(technique.id));
         } else if (stixObject instanceof Mitigation) {
-            return this.dataService.techniques.filter((technique: Technique) => (stixObject as Mitigation).relatedTechniques().includes(technique.id));
+            return allTechniques.filter((technique: Technique) => (stixObject as Mitigation).relatedTechniques().includes(technique.id));
         }
     }
 

--- a/nav-app/src/app/multiselect/multiselect.component.ts
+++ b/nav-app/src/app/multiselect/multiselect.component.ts
@@ -17,7 +17,8 @@ export class MultiselectComponent implements OnInit {
     constructor(private dataService: DataService) { 
         this.stixTypes = [{
             "label": "threat groups",
-            "objects": this.dataService.groups.sort((a,b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
+            "objects": this.dataService.groups.filter((group, i, arr) => arr.findIndex(t => t.id === group.id) === i)
+                       .sort((a,b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))
         }, {
             "label": "software",
             "objects": this.dataService.software.sort((a,b) => a.name.toLowerCase().localeCompare(b.name.toLowerCase()))

--- a/nav-app/src/app/techniques-search/techniques-search.component.ts
+++ b/nav-app/src/app/techniques-search/techniques-search.component.ts
@@ -50,14 +50,11 @@ export class TechniquesSearchComponent implements OnInit {
                 allTechniques = allTechniques.concat(technique.subtechniques);
             }
 
-            let re = new RegExp(this._query.trim(), "gi");
             let results = allTechniques.filter(function(technique: Technique) {
                 for (let field of self.fields) {
                     if (field.enabled) {
                         // query in this field
-                        let match = technique[field.field].search(re) != -1;
-                        // console.log("querying", field.label, "in", technique.name, ":", match)
-                        if (match) return true;
+                        return technique[field.field].toLowerCase().includes(self._query.trim().toLowerCase())
                     }
                 }
                 return false;


### PR DESCRIPTION
Removes duplicate threat group entries from the multiselect interface. Sub-techniques are also included when selecting techniques associated with threat groups, software, and mitigations.

Resolves Issue #164 