### PR TITLE
Select techniques with/without annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Updated the "select sub-techniques with parent" control under the "selection controls" dropdown. Sub-techniques will be selected independently by default. See issue [#140](https://github.com/mitre-attack/attack-navigator/issues/140).
 - Added sub-techniques as a configurable Navigator feature. Sub-technique features can be disabled by editing the `src/assets/config.json` file or using the "create customized Navigator" interface. See issue [#112](https://github.com/mitre-attack/attack-navigator/issues/112).
 - Added option to select scoring gradient from an existing layer in the _create layers from other layers_ interface. See issue [#121](https://github.com/mitre-attack/attack-navigator/issues/121).
+- Added options to select all techniques and sub-techniques with or without annotations in the context menu. See issue [#163](https://github.com/mitre-attack/attack-navigator/issues/163).
 
 ## Fixes
 - Added internet explorer support for the sub-techniques features, and improved Edge compatibility. See issue [#135](https://github.com/mitre-attack/attack-navigator/issues/135).

--- a/nav-app/src/app/help/help.component.html
+++ b/nav-app/src/app/help/help.component.html
@@ -598,8 +598,13 @@
             <li><b>invert selection:</b> Select all techniques that are not currently selected and unselect all techniques that are currently selected.</li>
             <li><b>select all:</b> Select all techniques.</li>
             <li><b>deselect all:</b> Deselect all techniques. This action can also be completed by the "deselect" (<img src="assets/icons/ic_clear_black_24px.svg"/>) button.</li>
+            <li><b>select annotated:</b> Select all techniques and sub-techniques which have annotations or remove unnanotated techniques from the selection.</li>
+            <li><b>select unannotated:</b> Select all techniques and sub-techniques which do not have annotations or remove annotated techniques from the selection.</li>
             <li><b>view technique:</b> For more information / details on the technique.</li>
         </ul>
+        <p><b>Tip:</b> You can use "select unannotated" followed by disabling those techniques, and then hiding disabled techniques, 
+            to create a layer where only annotated techniques are visible.
+        </p>
 
         <h2 id="help_Selection_Behavior">
             <img src="assets/icons/ic_lock_black_24px.svg">

--- a/nav-app/src/app/help/help.component.html
+++ b/nav-app/src/app/help/help.component.html
@@ -598,8 +598,8 @@
             <li><b>invert selection:</b> Select all techniques that are not currently selected and unselect all techniques that are currently selected.</li>
             <li><b>select all:</b> Select all techniques.</li>
             <li><b>deselect all:</b> Deselect all techniques. This action can also be completed by the "deselect" (<img src="assets/icons/ic_clear_black_24px.svg"/>) button.</li>
-            <li><b>select annotated:</b> Select all techniques and sub-techniques which have annotations or remove unnanotated techniques from the selection.</li>
-            <li><b>select unannotated:</b> Select all techniques and sub-techniques which do not have annotations or remove annotated techniques from the selection.</li>
+            <li><b>select annotated:</b> Select all techniques and sub-techniques which have annotations or remove unnanotated techniques from an existing selection.</li>
+            <li><b>select unannotated:</b> Select all techniques and sub-techniques which do not have annotations or remove annotated techniques from an existing selection.</li>
             <li><b>view technique:</b> For more information / details on the technique.</li>
         </ul>
         <p><b>Tip:</b> You can use "select unannotated" followed by disabling those techniques, and then hiding disabled techniques, 

--- a/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.html
+++ b/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.html
@@ -30,6 +30,14 @@
                 invert selection
             </div>
         </div>
+        <div *ngIf="configService.getFeature('selecting_techniques')" class="contextMenu-section">
+            <div class="contextMenu-button" (click)="selectAnnotated()">
+                select annotated
+            </div>
+            <div class="contextMenu-button" (click)="selectUnannotated()">
+                select unannotated
+            </div>
+        </div>
         <div class="contextMenu-section">
             <div class="contextMenu-button" (click)="viewTechnique()">
                 view technique

--- a/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.ts
+++ b/nav-app/src/app/matrix/technique-cell/contextmenu/contextmenu.component.ts
@@ -63,6 +63,16 @@ export class ContextmenuComponent extends CellPopover implements OnInit {
         this.closeContextmenu();
     }
 
+    private selectAnnotated() {
+        this.viewModel.selectAnnotated();
+        this.closeContextmenu();
+    }
+
+    private selectUnannotated() {
+        this.viewModel.selectUnannotated();
+        this.closeContextmenu();
+    }
+
     private viewTechnique() {
         window.open(this.technique.url, "_blank");
         this.closeContextmenu();

--- a/nav-app/src/app/viewmodels.service.ts
+++ b/nav-app/src/app/viewmodels.service.ts
@@ -642,6 +642,45 @@ export class ViewModel {
     }
 
     /**
+     * Select all techniques with annotations if nothing is currently selected, or select a subset of
+     * the current selection that has annotations
+     */
+    public selectAnnotated(): void {
+        let self = this;
+        if (this.isCurrentlyEditing()) {
+            // deselect techniques without annotations
+            let selected = new Set(this.selectedTechniques);
+            this.techniqueVMs.forEach(function(tvm, key) {
+                if (selected.has(tvm.technique_tactic_union_id) && !tvm.annotated()) self.selectedTechniques.delete(tvm.technique_tactic_union_id);
+            })
+        } else {
+            // select all techniques with annotations
+            this.techniqueVMs.forEach(function(tvm, key) {
+                if (tvm.annotated()) self.selectedTechniques.add(tvm.technique_tactic_union_id);
+            });
+        }
+    }
+
+    /**
+     * Select all techniques without annotations if nothing is currently selected, or select a subset of
+     * the current selection that do not have annotations
+     */
+    public selectUnannotated(): void {
+        let self = this;
+        if (this.isCurrentlyEditing()) {
+            // deselect techniques with annotations
+            let selected = new Set(this.selectedTechniques);
+            this.techniqueVMs.forEach(function(tvm, key) {
+                if (selected.has(tvm.technique_tactic_union_id) && tvm.annotated()) self.selectedTechniques.delete(tvm.technique_tactic_union_id);
+            })
+        } else {
+            // select all techniques without annotations
+            this.selectAnnotated();
+            this.invertSelection();
+        }
+    }
+
+    /**
      * Return true if the given technique is selected, false otherwise
      * @param  {Technique}  technique the technique to check
     * * @param  {Tactic}  tactic wherein the technique occurs
@@ -1246,6 +1285,14 @@ export class TechniqueVM {
      */
     modified(): boolean {
         return (this.score != "" || this.color != "" || !this.enabled || this.comment != "" || this.showSubtechniques);
+    }
+
+    /**
+     * Check if this TechniqueVM has been annotated
+     * @return true if it has annotations, false otherwise
+     */
+    annotated(): boolean {
+        return (this.score != "" || this.color != "" || !this.enabled || this.comment != "");
     }
 
     /**


### PR DESCRIPTION
Adds two buttons to the context menu to select annotated or select unannotated techniques and sub-techniques.

Resolves Issue #163 