### PR TITLE
Remove safari support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,13 +35,10 @@ Use our [GitHub Issue Tracker](https://github.com/mitre-attack/attack-navigator/
 * Chrome
 * Firefox
 * Internet Explorer 11<sup>[1]</sup>
-* Safari<sup>[2]</sup>
 * Edge
 * Opera
 
 **[1]** There is a recorded issue with the SVG export feature on Internet Explorer. Because of a [missing functionality on SVGElements](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/children) in that browser, text will not be properly vertically centered in SVGs exported in that browser. We recommend switching to a more modern browser for optimal results.
-
-**[2]** There is a recorded issue with using the **ATT&CK Navigator** on Safari. If the user reloads the page but cancels the action when prompted, the refresh icon in the browser window remains in the `cancel reload` state. This is believed to be an issue with Safari and not with the application.
 
 ## Install and Run
 #### First time

--- a/nav-app/src/app/exporter/exporter.component.html
+++ b/nav-app/src/app/exporter/exporter.component.html
@@ -1,7 +1,7 @@
 <div class="controlsContainer">
     <ul class="control-sections">
         <li class="iewarning" *ngIf="isIE()">
-            Warning: this interface is not fully compatable with your browser. For best results please switch to Edge, Chrome, Firefox or Safari.
+            Warning: this interface is not fully compatable with your browser. For best results please switch to Edge, Chrome, or Firefox.
         </li>
         <li>
             <div class="control-row-item noselect">

--- a/nav-app/src/app/help/help.component.html
+++ b/nav-app/src/app/help/help.component.html
@@ -710,7 +710,7 @@
         </p>
         <p>
             <b>Note:</b> this feature has minor compatability warnings
-            with the Internet Explorer browser. For best results, please use Safari, Firefox, Chrome or Edge.
+            with the Internet Explorer browser. For best results, please use Firefox, Chrome or Edge.
         </p>
         <p>
             Clicking the <i>download svg</i> button (<img src="assets/icons/ic_file_download_black_24px.svg">) will download

--- a/nav-app/src/app/tabs/tabs.component.html
+++ b/nav-app/src/app/tabs/tabs.component.html
@@ -35,6 +35,18 @@
     <button (click)="newBlankTab()">Start</button>
 </div>
 
+<ng-template #safariWarning>
+    <div class="safari-warning">
+        <h3>WARNING</h3>
+        <p>
+            We’ve detected that you are using the Safari browser. As of Navigator version <b>4.2</b>, Safari is no longer supported due to an unfixable freeze that can occur when selecting a layer tab.
+        </p>
+        <p>
+            We recommend you use Chrome or Firefox instead. You can continue to use the Navigator in Safari, but you may lose work if the application freezes.
+        </p>
+        <button mat-button (click)="safariDialogRef.close()">Dismiss</button>
+    </div>
+</ng-template>
 
 <div [style.margin-top]="configService.getFeature('tabs') || configService.getFeature('header') ? '0px' : '15px'">
     <ng-content></ng-content>

--- a/nav-app/src/app/tabs/tabs.component.scss
+++ b/nav-app/src/app/tabs/tabs.component.scss
@@ -284,3 +284,8 @@ input[type=file]{
     padding-left: 0;
     margin: 0;
 }
+
+.safari-warning {
+    text-align: center;
+    h3 { color: red; }
+}

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -1,5 +1,5 @@
 // https://embed.plnkr.co/wWKnXzpm8V31wlvu64od/
-import { Component, AfterContentInit, QueryList, ContentChildren, ViewChild, ComponentFactoryResolver } from '@angular/core';
+import { Component, AfterContentInit, QueryList, ContentChildren, ViewChild, ComponentFactoryResolver, TemplateRef, AfterViewInit } from '@angular/core';
 
 
 import { DynamicTabsDirective } from './dynamic-tabs.directive';
@@ -7,6 +7,7 @@ import { TabComponent } from '../tab/tab.component';
 import { DataService, Technique } from '../data.service'; //import the DataService component so we can use it
 import { ConfigService } from '../config.service';
 import { DataTableComponent} from '../datatable/data-table.component';
+import * as is from 'is_js';
 import { VersionUpgradeComponent } from '../version-upgrade/version-upgrade.component';
 
 import { ViewModelsService, ViewModel, TechniqueVM, Gradient, Gcolor } from "../viewmodels.service";
@@ -27,7 +28,7 @@ declare var math: any; //use mathjs
     providers: [ViewModelsService]
 
 })
-export class TabsComponent implements AfterContentInit {
+export class TabsComponent implements AfterContentInit, AfterViewInit {
 
     //  _____ _   ___   ___ _____ _   _ ___ ___
     // |_   _/_\ | _ ) / __|_   _| | | | __| __|
@@ -55,7 +56,7 @@ export class TabsComponent implements AfterContentInit {
 
     dynamicTabs: TabComponent[] = [];
     @ViewChild(DynamicTabsDirective) dynamicTabPlaceholder: DynamicTabsDirective;
-
+    @ViewChild('safariWarning') safariWarning : TemplateRef<any>; // Note: TemplateRef
 
     ngAfterContentInit() {
         this.ds.getConfig().subscribe((config: Object) => {
@@ -71,6 +72,16 @@ export class TabsComponent implements AfterContentInit {
             });
             this.customizedConfig = this.configService.getFeatureList()
         });
+    }
+
+    public safariDialogRef;
+    ngAfterViewInit() {
+        if (is.safari()) {
+            this.safariDialogRef = this.dialog.open(this.safariWarning, {
+                width: '350px',
+                disableClose: true
+            });
+        }
     }
 
     /**

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -56,7 +56,7 @@ export class TabsComponent implements AfterContentInit, AfterViewInit {
 
     dynamicTabs: TabComponent[] = [];
     @ViewChild(DynamicTabsDirective) dynamicTabPlaceholder: DynamicTabsDirective;
-    @ViewChild('safariWarning') safariWarning : TemplateRef<any>; // Note: TemplateRef
+    @ViewChild('safariWarning') safariWarning : TemplateRef<any>;
 
     ngAfterContentInit() {
         this.ds.getConfig().subscribe((config: Object) => {

--- a/nav-app/src/styles.scss
+++ b/nav-app/src/styles.scss
@@ -162,3 +162,7 @@ body {
     box-shadow: inset 0px 0px 0px 1px desaturate($cell-highlight-color, 100%);
 
 }
+
+.mat-button-focus-overlay {
+    background-color: transparent!important;
+}


### PR DESCRIPTION
Removes Safari support
- Adds a prompt to warn Safari users that the browser no longer supported
- Removes Safari from the help page and the list of supported browsers