### PR TITLE
Features/#252 consolidate cloud platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Added aggregate score that displays the combined score of the technique and all of its sub-techniques. See issue [#269](https://github.com/mitre-attack/attack-navigator/issues/269).
 - Added support for displaying notes in tooltips. Notes on a technique are indicated in the same style as a comment.
 - Fixed a bug in exporting matrix to Excel sheet, where the style of all sub-techniques with the same name in a column were incorrectly over-ridden by the style of the first sub-technique in its name. See issue [#270](https://github.com/mitre-attack/attack-navigator/issues/270).
+- Consolidated AWS, GCP, and Azure platforms into IaaS platform to integrate upcoming release of ATT&CK. See issue [#252](https://github.com/mitre-attack/attack-navigator/issues/252). 
 
 # v4.2 - 3 February 2021
 

--- a/nav-app/src/app/datatable/data-table.component.html
+++ b/nav-app/src/app/datatable/data-table.component.html
@@ -215,7 +215,7 @@ o888     88 o888   888o 8888o  88  88  888  88  888    888 o888   888o 888      
                             <div class="filter-option" *ngFor="let filterOption of viewModel.filters[filter].options" >
                                 <!-- <label class="noselect"><input type="checkbox" (click)="viewModel.filters.toggleInFilter(filter, filterOption); filterTechniques()" [checked]="viewModel.filters.inFilter(filter, filterOption)">{{filterOption}}</label> -->
                                 <input [id]="filterOption" class="checkbox-custom" type="checkbox" (click)="viewModel.filters.toggleInFilter(filter, filterOption);" [checked]="viewModel.filters.inFilter(filter, filterOption)">
-                                <label for="{{filterOption}}" class="checkbox-custom-label noselect">{{filterOption}}</label>
+                                <label [for]="filterOption" class="checkbox-custom-label noselect">{{filterOption}}</label>
                             </div>
                         </div>
                         <div *ngIf="viewModel.filters[filter].options.length == 0">

--- a/nav-app/src/app/viewmodels.service.ts
+++ b/nav-app/src/app/viewmodels.service.ts
@@ -1568,17 +1568,19 @@ export class Filter {
 
                     "windows": "Windows",
                     "linux": "Linux",
-                    "mac": "macOS"
+                    "mac": "macOS",
+
+                    "AWS": "IaaS",
+                    "GCP": "IaaS",
+                    "Azure": "IaaS"
                 }
-                this.platforms.selection = rep.platforms.map(function(platform) {
-                    if (platform in backwards_compatibility_mappings) {
-                        return backwards_compatibility_mappings[platform];
-                    } else {
-                        return platform;
-                    }
+                const selection = new Set<string>();
+                rep.platforms.forEach(function (platform) {
+                    if (platform in backwards_compatibility_mappings) selection.add(backwards_compatibility_mappings[platform]);
+                    else selection.add(platform);
                 });
-            }
-            else console.error("TypeError: filter platforms field is not a string[]");
+                this.platforms.selection = Array.from(selection);
+            } else console.error("TypeError: filter platforms field is not a string[]");
         }
     }
 }


### PR DESCRIPTION
Feature add for [#252](https://github.com/mitre-attack/attack-navigator/issues/252).

Tested this feature by changing the config.json file to use latest version of STIX data as ATT&CK version 8 (to avoid errors), and imported an older data layer with the platforms "Azure", "GCP", and "AWS". The Navigator will then automatically deserialize the 3 platforms into the "IaaS" platform.