### PR TITLE
Fix/#204 technique hover

### DIFF
--- a/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
+++ b/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
@@ -24,33 +24,22 @@ export class TechniqueCellComponent implements OnInit {
         if (this.showContextmenu) return false;
         if (this.viewModel.highlightedTechniques.size === 0) return false;
 
-        return (this.viewModel.highlightedTechniques.has(this.technique.id) && this.viewModel.highlightedTactic && this.viewModel.highlightedTactic.id == this.tactic.id);
+        return (this.viewModel.highlightedTechnique === this.technique && this.viewModel.highlightedTactic && this.viewModel.highlightedTactic.id === this.tactic.id);
     }
 
-    // isHighlighted() checks for three cases:
-    //     1) if selectTechniquesAcrossTactics is enabled,
-    //     2) if selectSubtechniquesWithParent is enabled,
-    //     3) if highlightedTactic exists
-    // If 1) is enabled, it searches through the highlightedTechniques array for the current technique's id
-    // And if 2) is enabled, it searches through the highlightedTechniques array for the current technique's parent's id
-    // If 3) is null, then the highlight is coming from the techniques search component, otherwise it is from the mouseover event in the matrix.
+
     public get isHighlighted(): boolean {
         let isHighlighted = this.showContextmenu;
+        let idToMatch = this.technique.id;
+        if (this.viewModel.selectSubtechniquesWithParent && this.technique.isSubtechnique) idToMatch = this.technique.parent.id;
 
-        if (this.viewModel.selectTechniquesAcrossTactics) {
-            isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
-        } else if (!this.viewModel.selectTechniquesAcrossTactics && this.viewModel.highlightedTactic) isHighlighted = (this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.id));
-        if (this.viewModel.selectSubtechniquesWithParent) {
-            if (!this.viewModel.selectTechniquesAcrossTactics && this.viewModel.highlightedTactic) {
-                if (this.technique.isSubtechnique) isHighlighted = this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.parent.id)
-                else isHighlighted = this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.id);
-            } else {
-                if (this.technique.isSubtechnique) isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.parent.id)
-                else isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
+        if (this.viewModel.highlightedTechniques.has(idToMatch)) {
+            if (!this.viewModel.highlightedTactic) { // highlight is called from search component
+                return true;
+            } else if (this.viewModel.highlightedTactic) {
+                const isTacticMatching = this.viewModel.highlightedTactic === this.tactic;
+                return (this.viewModel.selectTechniquesAcrossTactics || isTacticMatching);
             }
-        }
-        if (!this.viewModel.selectTechniquesAcrossTactics && !this.viewModel.selectSubtechniquesWithParent && !this.viewModel.highlightedTactic) {
-            isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
         }
 
         return isHighlighted;

--- a/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
+++ b/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
@@ -27,22 +27,33 @@ export class TechniqueCellComponent implements OnInit {
         return (this.viewModel.highlightedTechniques.has(this.technique.id) && this.viewModel.highlightedTactic && this.viewModel.highlightedTactic.id == this.tactic.id);
     }
 
+    // isHighlighted() checks for three cases:
+    //     1) if selectTechniquesAcrossTactics is enabled,
+    //     2) if selectSubtechniquesWithParent is enabled,
+    //     3) if highlightedTactic exists
+    // If 1) is enabled, it searches through the highlightedTechniques array for the current technique's id
+    // And if 2) is enabled, it searches through the highlightedTechniques array for the current technique's parent's id
+    // If 3) is null, then the highlight is coming from the techniques search component, otherwise it is from the mouseover event in the matrix.
     public get isHighlighted(): boolean {
+        let isHighlighted = this.showContextmenu;
+
         if (this.viewModel.selectTechniquesAcrossTactics) {
-            if (this.viewModel.selectSubtechniquesWithParent) {
-                return this.technique.isSubtechnique && this.viewModel.highlightedTechniques.has(this.technique.parent.id);
+            isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
+        } else if (!this.viewModel.selectTechniquesAcrossTactics && this.viewModel.highlightedTactic) isHighlighted = (this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.id));
+        if (this.viewModel.selectSubtechniquesWithParent) {
+            if (!this.viewModel.selectTechniquesAcrossTactics && this.viewModel.highlightedTactic) {
+                if (this.technique.isSubtechnique) isHighlighted = this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.parent.id)
+                else isHighlighted = this.viewModel.highlightedTactic === this.tactic && this.viewModel.highlightedTechniques.has(this.technique.id);
+            } else {
+                if (this.technique.isSubtechnique) isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.parent.id)
+                else isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
             }
         }
-        else if (this.viewModel.highlightedTactic && this.viewModel.highlightedTactic.id == this.tactic.id) {
-            if (this.viewModel.selectSubtechniquesWithParent) {
-                return this.technique.isSubtechnique && this.viewModel.highlightedTechniques.has(this.technique.parent.id);
-            }
-        }
-        if (this.viewModel.highlightedTechniques.has(this.technique.id)) { // for highlighting techniques from the techniques search component, where highlightedTactic is null
-            return true;
+        if (!this.viewModel.selectTechniquesAcrossTactics && !this.viewModel.selectSubtechniquesWithParent && !this.viewModel.highlightedTactic) {
+            isHighlighted = this.viewModel.highlightedTechniques.has(this.technique.id);
         }
 
-        return this.showContextmenu;
+        return isHighlighted;
     }
 
     constructor(public configService: ConfigService, public dataService: DataService) { }

--- a/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
+++ b/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts
@@ -36,7 +36,7 @@ export class TechniqueCellComponent implements OnInit {
         if (this.viewModel.highlightedTechniques.has(idToMatch)) {
             if (!this.viewModel.highlightedTactic) { // highlight is called from search component
                 return true;
-            } else if (this.viewModel.highlightedTactic) {
+            } else {
                 const isTacticMatching = this.viewModel.highlightedTactic === this.tactic;
                 return (this.viewModel.selectTechniquesAcrossTactics || isTacticMatching);
             }

--- a/nav-app/src/app/viewmodels.service.ts
+++ b/nav-app/src/app/viewmodels.service.ts
@@ -498,6 +498,7 @@ export class ViewModel {
 
     public highlightedTactic: Tactic = null;
     public highlightedTechniques: Set<string> = new Set<string>();
+    public highlightedTechnique: Technique = null; // the Technique that was actually moused over
 
     /**
      * Highlight the given technique under the given tactic
@@ -506,6 +507,7 @@ export class ViewModel {
      */
     public highlightTechnique(technique: Technique, tactic?: Tactic | null) {
         if (this.selectSubtechniquesWithParent && technique.isSubtechnique) this.highlightedTechniques.add(technique.parent.id);
+        this.highlightedTechnique = technique;
         this.highlightedTechniques.add(technique.id);
         this.highlightedTactic = tactic;
     }
@@ -514,6 +516,7 @@ export class ViewModel {
      */
     public clearHighlight() {
         this.highlightedTactic = null;
+        this.highlightedTechnique = null;
         this.highlightedTechniques = new Set<string>();
     }
 


### PR DESCRIPTION
Fixed bug where the `select techniques across parents` / `select sub-techniques with parent behavior` on hover were not correct.

Only concern I have is that I've removed the [line comparing the attackIDs of the current and highlighted techniques to see if it should be highlighted](https://github.com/mitre-attack/attack-navigator/blob/a7d4703365db515c472d0c06436227c83eb26015/nav-app/src/app/matrix/technique-cell/technique-cell.component.ts#L38):
`if (compare.attackID == compareTo.attackID) return true;`
This was removed because instead of storing Technique in the highlightedTechniques, I'm now saving an array of the technique IDs, for faster lookup (and because the search component needs it as an array). I'm hoping that checking both the technique and tactic when the user hovers over a cell in the matrix should suffice.