### PR TITLE
Added check for if Safari version is 13. and below to show incompatibility warning dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Fixed issue with sorting when show aggregate score is enabled, where each technique's aggregate score was not correctly calculated into the sorting. See issue [#295](https://github.com/mitre-attack/attack-navigator/issues/295). 
 - The Navigator should now use the proper fonts when operating without an internet connection. See issue [#278](https://github.com/mitre-attack/attack-navigator/issues/278)
 - Fixed an issue when loading multiple default layers where subsequent layers would only appear after the user interacted with the first one. See issue [#288](https://github.com/mitre-attack/attack-navigator/issues/288).
+- Updated Safari browser warning to show only for versions 13 and below. See issue [#306](https://github.com/mitre-attack/attack-navigator/issues/306).
 
 
 # v4.3 - 29 April 2021

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # v4.4 - Changes staged on Develop
 
+Version 4.4 of the Navigator restores Safari support provided you are using Safari version 14 or above.
+
 ## Improvements
 - Combined the search and multiselect interfaces into a single UI. This allows groups, software, and mitigations to be filtered alongside techniques and improves usability by moving the interface to a sidebar. See issue [#204](https://github.com/mitre-attack/attack-navigator/issues/204). 
 - Improved favicon for standardization with other ATT&CK tools.

--- a/README.md
+++ b/README.md
@@ -37,8 +37,11 @@ Use our [GitHub Issue Tracker](https://github.com/mitre-attack/attack-navigator/
 * Internet Explorer 11<sup>[1]</sup>
 * Edge
 * Opera
+* Safari <sup>[2]</sup>
 
 **[1]** There is a recorded issue with the SVG export feature on Internet Explorer. Because of a [missing functionality on SVGElements](https://developer.mozilla.org/en-US/docs/Web/API/ParentNode/children) in that browser, text will not be properly vertically centered in SVGs exported in that browser. We recommend switching to a more modern browser for optimal results.
+
+**[2]** ATT&CK Navigator only supports Safari versions 14 and above because older versions of the browser can exhibit an unfixable freeze when selecting a layer tab. Users on unsupported versions of the browser will be warned of this possibility when opening the application.
 
 ## Install and Run
 #### First time

--- a/nav-app/src/app/tabs/tabs.component.html
+++ b/nav-app/src/app/tabs/tabs.component.html
@@ -54,10 +54,10 @@
     <div class="safari-warning">
         <h3>WARNING</h3>
         <p>
-            We’ve detected that you are using the Safari browser. As of Navigator version <b>4.2</b>, Safari is no longer supported due to an unfixable freeze that can occur when selecting a layer tab.
+            We’ve detected that you are using the Safari browser. As of Navigator version <b>4.3</b>, Safari versions 13 and below are not supported due to an unfixable freeze that can occur when selecting a layer tab.
         </p>
         <p>
-            We recommend you use Chrome or Firefox instead. You can continue to use the Navigator in Safari, but you may lose work if the application freezes.
+            We recommend you use Chrome or Firefox instead. You can continue to use the Navigator in Safari (versions 13 and below), but you may lose work if the application freezes.
         </p>
         <button mat-button (click)="safariDialogRef.close()">Dismiss</button>
     </div>

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -69,7 +69,7 @@ export class TabsComponent implements AfterContentInit, AfterViewInit {
 
     public safariDialogRef;
     ngAfterViewInit() {
-        if (is.safari()) {
+        if (is.safari('<=13')) {
             this.safariDialogRef = this.dialog.open(this.safariWarning, {
                 width: '350px',
                 disableClose: true


### PR DESCRIPTION
Fix uses the existing `is_js `dependency.

This fix was tested using the Safari browser's Develop tool (via user agent in the menu) to run the app using version 13.0 and 14.0 on my Mac. It doesn't seem possible to downgrade Safari versions, so this seems to be the best way of testing it.