### PR TITLE
Layer upgrade fixes

### DIFF
--- a/nav-app/src/app/data.service.ts
+++ b/nav-app/src/app/data.service.ts
@@ -43,7 +43,7 @@ export class DataService {
      * @param domain
      * @param stixBundles
      */
-    parseBundle(domain: Domain, stixBundles: any[], includeAll: boolean = false): void {
+    parseBundle(domain: Domain, stixBundles: any[]): void {
         let platforms = new Set<String>();
         let seenIDs = new Set<String>();
         for (let bundle of stixBundles) {
@@ -52,9 +52,6 @@ export class DataService {
             let idToTechniqueSDO = new Map<string, any>();
             let idToTacticSDO = new Map<string, any>();
             for (let sdo of bundle.objects) { //iterate through stix domain objects in the bundle
-                // ignore deprecated and revoked objects in the bundle?
-                if (!includeAll && (sdo.x_mitre_deprecated || sdo.revoked)) continue;
-                
                 // Filter out object not included in this domain if domains field is available
                 if ("x_mitre_domains" in sdo && !sdo.x_mitre_domains.includes(domain.domain_identifier)) continue; 
                 
@@ -270,14 +267,14 @@ export class DataService {
     /**
      * Load and parse domain data
      */
-    loadDomainData(domainVersionID: string, refresh: boolean = false, includeAll: boolean = false): Promise<any> {
+    loadDomainData(domainVersionID: string, refresh: boolean = false): Promise<any> {
         let dataPromise: Promise<any> = new Promise((resolve, reject) => {
             let domain = this.getDomain(domainVersionID);
             if (domain.dataLoaded && !refresh) resolve(null);
             if (domain) {
                 let subscription = this.getDomainData(domain, refresh).subscribe({
                     next: (data: Object[]) => {
-                        this.parseBundle(domain, data, includeAll);
+                        this.parseBundle(domain, data);
                         resolve(null);
                     },
                     complete: () => { if (subscription) subscription.unsubscribe(); } //prevent memory leaks

--- a/nav-app/src/app/layer-upgrade/changelog-cell/changelog-cell.component.ts
+++ b/nav-app/src/app/layer-upgrade/changelog-cell/changelog-cell.component.ts
@@ -47,6 +47,7 @@ export class ChangelogCellComponent extends Cell implements OnInit {
             }
             // select technique
             else {
+                this.viewModel.clearSelectedTechniques();
                 this.viewModel.selectTechnique(this.technique, this.tactic);
             }
             this.viewModelsService.selectionChanged(); // emit selection change

--- a/nav-app/src/app/layer-upgrade/layer-upgrade.component.scss
+++ b/nav-app/src/app/layer-upgrade/layer-upgrade.component.scss
@@ -115,3 +115,13 @@ tr td {
     span { font-size: 14px; }
     &.center { text-align: center; }
 }
+.spinner {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 50vh;
+
+    mat-progress-spinner circle {
+        stroke: on-color-deemphasis(body);
+    }
+}

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -535,8 +535,8 @@ export class TabsComponent implements AfterContentInit, AfterViewInit {
 
                 // load layer version & latest ATT&CK version
                 let loads: any = {};
-                if (!this.dataService.getDomain(versions.oldID).dataLoaded) loads.old = this.dataService.loadDomainData(versions.oldID, true, true);
-                if (!this.dataService.getDomain(versions.newID).dataLoaded) loads.new = this.dataService.loadDomainData(versions.newID, true, true);
+                if (!this.dataService.getDomain(versions.oldID).dataLoaded) loads.old = this.dataService.loadDomainData(versions.oldID, true);
+                if (!this.dataService.getDomain(versions.newID).dataLoaded) loads.new = this.dataService.loadDomainData(versions.newID, true);
                 if (Object.keys(loads).length) {
                     let dataSubscription = forkJoin(loads).subscribe({
                         next: () => {


### PR DESCRIPTION
Includes bug fixes for the layer upgrade workflow:
- Fixed bug where selecting techniques in the interface behaved as a "shift + click" selection, which caused the selections to accumulate rather than selecting one technique at a time.
- Fixed a bug where uploading an outdated layer without upgrading to the latest version would omit revoked/deprecated objects, causing any subsequent layer upgrades to be missing objects in the version comparison.
- Added styling for the technique loading spinners in the workflow steps.