### PR TITLE
fix for #354: avoid loading revoked/deprecated techniques from layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v4.4.1 - 16 September 2021
+
+## Fixes
+- Fixed a crash that would occur when loading a layer with annotations on a revoked/deprecated technique without explicitly defined tactics. See issue [#354](https://github.com/mitre-attack/attack-navigator/issues/354).
+
 # v4.4 - 15 September 2021
 
 Version 4.4 of the Navigator restores Safari support provided you are using Safari version 14 or above.

--- a/nav-app/src/app/viewmodels.service.ts
+++ b/nav-app/src/app/viewmodels.service.ts
@@ -1311,6 +1311,9 @@ export class ViewModel {
                         for (let technique of this.dataService.getDomain(this.domainVersionID).techniques) {
                             if (technique.attackID == obj_technique.techniqueID) {
                                 // match technique
+                                // don't load deprecated/revoked, causes crash since tactics don't get loaded on revoked techniques
+                                if (technique.deprecated || technique.revoked) break;
+                                
                                 for (let tactic of technique.tactics) {
                                     let tvm = new TechniqueVM("");
                                     tvm.deSerialize(JSON.stringify(obj_technique),
@@ -1323,6 +1326,9 @@ export class ViewModel {
                             //check against subtechniques
                             for (let subtechnique of technique.subtechniques) {
                                 if (subtechnique.attackID == obj_technique.techniqueID) {
+                                    // don't load deprecated/revoked, causes crash since tactics don't get loaded on revoked techniques
+                                    if (subtechnique.deprecated || subtechnique.revoked) break;
+
                                     for (let tactic of subtechnique.tactics) {
                                         let tvm = new TechniqueVM("");
                                         tvm.deSerialize(JSON.stringify(obj_technique),


### PR DESCRIPTION
Resolves #354. Layers which defined annotations on revoked/deprecated techniques without explicitly defining their tactics could previously crash the application when loaded, since the tactics of a revoked/deprecated technique cannot always be inferred due to the ATT&CK data model. 

The bug was introduced with v4.4 of the Navigator, which changed the handling of revoked/deprecated objects due to requirements of the layer upgrade workflow.

With this PR annotations will not be loaded for revoked/deprecated techniques in the first place, avoiding the crash. 