### PR TITLE
Feature/#341 data sources v10 support

### DIFF
--- a/nav-app/src/app/data.service.ts
+++ b/nav-app/src/app/data.service.ts
@@ -601,10 +601,16 @@ export class DataComponent {
    * @returns {string[]} technique IDs used by this data component
    */
   public techniques(domainVersionID): string[] {
+    const techniques = [];
     const domain = this.dataService.getDomain(domainVersionID);
     let rels = domain.relationships.component_rel;
-    if (rels.has(this.id)) return rels.get(this.id).map((targetID) => domain.techniques.find((t) => t.id === targetID));
-    return [];
+    if (rels.has(this.id)) {
+      rels.get(this.id).forEach((targetID) => {
+        const t = domain.techniques.find((t) => t.id === targetID);
+        if (t) techniques.push(t);
+      })
+    }
+    return techniques;
   }
   /**
    * get data source related to this data component

--- a/nav-app/src/app/data.service.ts
+++ b/nav-app/src/app/data.service.ts
@@ -53,14 +53,21 @@ export class DataService {
             let idToTacticSDO = new Map<string, any>();
             for (let sdo of bundle.objects) { //iterate through stix domain objects in the bundle
                 // Filter out object not included in this domain if domains field is available
-                if ("x_mitre_domains" in sdo && !sdo.x_mitre_domains.includes(domain.domain_identifier)) continue; 
-                
+                if ("x_mitre_domains" in sdo && !sdo.x_mitre_domains.includes(domain.domain_identifier)) continue;
+
                 // filter out duplicates
                 if (!seenIDs.has(sdo.id)) seenIDs.add(sdo.id)
                 else continue;
 
                 // parse according to type
                 switch(sdo.type) {
+                    case "x-mitre-data-component":
+                        // console.log('DATA COMPONENT', sdo);
+                        domain.dataComponents.push(new DataComponent(sdo, this));
+                        break;
+                    case "x-mitre-data-source":
+                        domain.dataSources.set(sdo.id, {name: sdo.name, external_references: sdo.external_references});
+                        break;
                     case "intrusion-set":
                         domain.groups.push(new Group(sdo, this));
                         break;
@@ -109,6 +116,13 @@ export class DataService {
                         } else if (sdo.relationship_type == 'revoked-by') {
                             // record stix object: stix object relationship
                             domain.relationships["revoked_by"].set(sdo.source_ref, sdo.target_ref)
+                        } else if (sdo.relationship_type === 'detects') {
+                            if (domain.relationships["component_rel"].has(sdo.source_ref)) {
+                                let ids = domain.relationships["component_rel"].get(sdo.source_ref);
+                                ids.push(sdo.target_ref);
+                            } else {
+                                domain.relationships["component_rel"].set(sdo.source_ref, [sdo.target_ref])
+                            }
                         }
                         break;
                     case "attack-pattern":
@@ -573,6 +587,51 @@ export class VersionChangelog {
 }
 
 /**
+ * Object representing a Data Component in the ATT&CK catalogue
+ */
+export class DataComponent {
+  public readonly description: string;
+  public readonly url: string;
+  public readonly id: string;
+  public readonly name: string;
+  public readonly dataSource: string;
+  protected readonly dataService: DataService;
+  /**
+   * get techniques related to this data component
+   * @returns {string[]} technique IDs used by this data component
+   */
+  public techniques(domainVersionID): string[] {
+    const domain = this.dataService.getDomain(domainVersionID);
+    let rels = domain.relationships.component_rel;
+    if (rels.has(this.id)) return rels.get(this.id).map((targetID) => domain.techniques.find((t) => t.id === targetID));
+    return [];
+  }
+  /**
+   * get data source related to this data component
+   * @returns {name: string, url: string} name, and first url of data source referenced by this data component
+   */
+  public source(domainVersionID) {
+    const dataSources = this.dataService.getDomain(domainVersionID).dataSources;
+    if (dataSources.has(this.dataSource)) {
+      const source = dataSources.get(this.dataSource);
+      let url = "";
+      if (source.external_references && source.external_references[0] && source.external_references[0].url)
+        url = source.external_references[0].url;
+      return {name: source.name, url: url};
+    }
+    else return {name: '', url: ''};
+  }
+
+  constructor(stixSDO: any, dataService: DataService) {
+    this.description = stixSDO.description
+    this.id = stixSDO.id;
+    this.name = stixSDO.name;
+    this.dataService = dataService;
+    this.dataSource = stixSDO.x_mitre_data_source_ref;
+  }
+}
+
+/**
  * Object representing a Software (tool, malware) in the ATT&CK catalogue
  */
 export class Software extends BaseStix {
@@ -604,6 +663,7 @@ export class Software extends BaseStix {
         return this.used(domainVersionID);
     }
 }
+
 /**
  * Object representing a Group (intrusion-set) in the ATT&CK catalogue
  */
@@ -693,6 +753,8 @@ export class Domain {
     public platforms: String[] = []; // platforms defined on techniques and software of the domain
     public subtechniques: Technique[] = [];
     public software: Software[] = [];
+    public dataComponents: DataComponent[] = [];
+    public dataSources = new Map<string, { name: string, external_references: any[] }>(); // Map data source ID to name and urls to be used by data components
     public groups: Group[] = [];
     public mitigations: Mitigation[] = [];
     public notes: Note[] = [];
@@ -700,6 +762,9 @@ export class Domain {
         // subtechnique subtechnique-of technique
         // ID of technique to [] of subtechnique IDs
         subtechniques_of: new Map<string, string[]>(),
+        // data component related to technique
+        // ID of data component to [] of technique IDs
+        component_rel: new Map<string, string[]>(),
         // group uses technique
         // ID of group to [] of technique IDs
         group_uses: new Map<string, string[]>(),

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
@@ -67,7 +67,7 @@
                 </ng-template>
             </mat-expansion-panel>
 
-            <mat-expansion-panel *ngFor="let stixType of stixTypes" class="stixType" [expanded]="stixType.isExpanded" (click)="userClickedExpand = true">
+            <mat-expansion-panel *ngFor="let stixType of stixTypes; let i = index" class="stixType" [expanded]="expandedPanels[i+1]" (click)="userClickedExpand = true">
                 <mat-expansion-panel-header>
                     <mat-panel-title>
                         <h4>

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
@@ -105,6 +105,46 @@
                     </div>
                 </ng-template>
             </mat-expansion-panel>
+
+            <mat-expansion-panel [expanded]="expandedPanels[4]" (click)="userClickedExpand = true">
+                <mat-expansion-panel-header>
+                    <mat-panel-title>
+                        <h4>
+                            Data Sources ({{stixDataComponentLabels.length}})
+                        </h4>
+                    </mat-panel-title>
+                    <mat-panel-description>
+                    </mat-panel-description>
+                </mat-expansion-panel-header>
+
+                <ng-template matExpansionPanelContent>
+                    <div class="allresults-buttons">
+                        <button class="button" (click)="selectAll(stixDataComponentsResults, true)">select all</button>
+                        <button class="button" (click)="deselectAll(stixDataComponentsResults, true)">deselect all</button>
+                    </div>
+                    <div class="results objects">
+                        <table *ngIf="stixDataComponentLabels.length > 0; else noResults">
+                            <tr  *ngFor="let label of stixDataComponentLabels">
+                                <td>{{ label }}</td>
+<!--                                <td (mouseenter)="mouseEnter(stixObject, false)"-->
+<!--                                    (mouseleave)="mouseLeave()">-->
+<!--                                    {{stixObject.name}}-->
+<!--                                </td>-->
+                                <td><a href="{{stixDataComponents.get(label).url}}" target="_blank">view</a></td>
+                                <td>
+                                    <button class="button" (click)="selectAll(stixDataComponents.get(label).objects, true)">select</button>
+                                </td>
+                                <td>
+                                    <button class="button" (click)="deselectAll(stixDataComponents.get(label).objects, true)">deselect</button>
+                                </td>
+                            </tr>
+                        </table>
+                        <ng-template #noResults>
+                            <div class="no-results">no results for data sources</div>
+                        </ng-template>
+                    </div>
+                </ng-template>
+            </mat-expansion-panel>
         </mat-accordion>
     </div>
 

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
@@ -125,11 +125,10 @@
                     <div class="results objects">
                         <table *ngIf="stixDataComponentLabels.length > 0; else noResults">
                             <tr  *ngFor="let label of stixDataComponentLabels">
-                                <td>{{ label }}</td>
-<!--                                <td (mouseenter)="mouseEnter(stixObject, false)"-->
-<!--                                    (mouseleave)="mouseLeave()">-->
-<!--                                    {{stixObject.name}}-->
-<!--                                </td>-->
+                                <td (mouseenter)="mouseEnterAll(stixDataComponents.get(label).objects)"
+                                    (mouseleave)="mouseLeave()">
+                                    {{ label }}
+                                </td>
                                 <td><a href="{{stixDataComponents.get(label).url}}" target="_blank">view</a></td>
                                 <td>
                                     <button class="button" (click)="selectAll(stixDataComponents.get(label).objects, true)">select</button>

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
@@ -18,11 +18,11 @@ export class SearchAndMultiselectComponent implements OnInit {
     public stixDataComponentLabels: string[];
     userClickedExpand = false;
     expandedPanels = {
-        0: true,
-        1: false,
-        2: false,
-        3: false,
-        4: false
+        0: true, // techniques panel
+        1: false, // groups panel
+        2: false, // software panel
+        3: false, // mitigations panel
+        4: false // data components panel
     };
 
     public fields = [
@@ -165,18 +165,21 @@ export class SearchAndMultiselectComponent implements OnInit {
     expandPanels() {
         if (!this.userClickedExpand) {
             this.expandedPanels[0] = this.techniqueResults.length > 0;
-            let isPrevExpanded = this.expandedPanels[0]
+            let isPrevExpanded = this.expandedPanels[0];
             if (!isPrevExpanded) {
                 this.stixTypes.forEach((s, i) => {
-                    s.isExpanded = !isPrevExpanded && s.objects.length > 0;
-                    this.expandedPanels[i+1] = s.isExpanded;
-                    isPrevExpanded = s.isExpanded;
+                  this.expandedPanels[i+1] = !isPrevExpanded && s.objects.length > 0;
+                  isPrevExpanded = s.isExpanded;
                 });
             }
+            this.expandedPanels[4] = (!isPrevExpanded && this.stixDataComponentLabels.length > 0);
         } else {
             let isAllCollapsed = false;
-            for (const item in this.expandedPanels) {
-                isAllCollapsed = !item;
+            for (const isPanelExpanded in this.expandedPanels) {
+                if (isPanelExpanded) {
+                  isAllCollapsed = true;
+                  break;
+                }
             }
             this.userClickedExpand = isAllCollapsed;
         }
@@ -196,16 +199,13 @@ export class SearchAndMultiselectComponent implements OnInit {
 
         this.stixTypes = [{
             "label": "threat groups",
-            "objects": this.filterAndSort(domain.groups, this._query),
-            "isExpanded": false
+            "objects": this.filterAndSort(domain.groups, this._query)
         }, {
             "label": "software",
-            "objects": this.filterAndSort(domain.software, this._query),
-            "isExpanded": false
+            "objects": this.filterAndSort(domain.software, this._query)
         }, {
             "label": "mitigations",
-            "objects": this.filterAndSort(domain.mitigations, this._query),
-            "isExpanded": false
+            "objects": this.filterAndSort(domain.mitigations, this._query)
         }];
 
         domain.dataComponents.forEach((c) => {

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
@@ -71,8 +71,12 @@ export class SearchAndMultiselectComponent implements OnInit {
         return this._query.length;
     }
 
-    public get stixDataComponentsResults() {
-      return this.stixDataComponentLabels.map((label) => this.stixDataComponents.get(label).objects);
+    public get stixDataComponentsResults(): Technique[] {
+      let results = [];
+      this.stixDataComponentLabels.forEach((label) => {
+        results = results.concat(this.stixDataComponents.get(label).objects);
+      });
+      return results;
     }
 
     public techniqueResults: Technique[] = [];
@@ -227,6 +231,10 @@ export class SearchAndMultiselectComponent implements OnInit {
                 break;
             }
         }
+    }
+
+    public mouseEnterAll(techniques: Technique[]) {
+      techniques.forEach((t) => this.mouseEnter(t));
     }
 
     public mouseEnter(technique: Technique, isTechnique = true): void {


### PR DESCRIPTION
Adding search data sources to search + multiselect interface--user can now:
- search for techniques by their related {{ data source }}: {{ data component }}
- hover over a data component to preview its techniques
- click on a link that will take them to the ATT&CK site to view more details about the data source