### PR TITLE
Fix loading for multiple layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.5.2 - changes staged on develop
+## Fixes
+- Fixed an issue when loading multiple default layers (specified in the config or a layerURL) which led to only the first layer being loaded. See issue [#361](https://github.com/mitre-attack/attack-navigator/issues/361).
+
 # v4.5.1 - 21 October 2021
 
 ## Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # v4.5.2 - changes staged on develop
+
+## Improvements
+- Users will no longer be prompted to upgrade default layers (set in the config file or the "create a customized Navigator" feature) to the current ATT&CK version. This should improve the UX of Navigator instances embedded in iframes or linked to from webpages with a default set of layers loaded. 
+
 ## Fixes
 - Fixed an issue when loading multiple default layers (specified in the config or a layerURL) which led to only the first layer being loaded. See issue [#361](https://github.com/mitre-attack/attack-navigator/issues/361).
 

--- a/README.md
+++ b/README.md
@@ -174,6 +174,8 @@ Local files to load should be placed in the `nav-app/src/assets/` directory.
 
 Default layers from the web can also be set using a query string in the Navigator URL. Refer to the in-application help page section "Customizing the Navigator" for more details.
 
+Users will not be prompted to upgrade default layers to the current version of ATT&CK if they are outdated.
+
 ## Enabling Banner in Navigator
 The `banner` setting in `nav-app/src/assets/config.json` by default is an empty string `"""` (and not visible), and can be set to whatever content you wish to display inside a banner at the top of the Navigator webpage. The banner supports HTML and hyperlinks in the content.
 

--- a/USAGE.md
+++ b/USAGE.md
@@ -492,6 +492,8 @@ from <a href="https://github.com/mitre-attack/attack-navigator">our github
 repo</a>:  
 <code>https://mitre-attack.github.io/attack-navigator/enterprise/<b>#layerURL=https%3A%2F%2Fraw.githubusercontent.com%2Fmitre%2Fattack-navigator%2Fmaster%2Flayers%2Fdata%2Fsamples%2FBear_APT.json</b></code>
 
+Users will not be prompted to upgrade default layers to the current version of ATT&CK if they are outdated.
+
 ## Disabling Features
 
 Individual ATT&CK Navigator features can be disabled with the checkboxes. Removing a feature only removes the interface

--- a/nav-app/package-lock.json
+++ b/nav-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-navigator",
-  "version": "4.5.1",
+  "version": "4.5.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nav-app/package.json
+++ b/nav-app/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/mitre-attack/attack-navigator.git"
   },
-  "version": "4.5.1",
+  "version": "4.5.2",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/nav-app/src/app/globals.ts
+++ b/nav-app/src/app/globals.ts
@@ -5,5 +5,5 @@
  //
 'use strict';
 
-export const nav_version: string="4.5.1"
+export const nav_version: string="4.5.2"
 export const layer_version: string="4.2"


### PR DESCRIPTION
Fixes #361. Previously, the await for the first layer to be loaded never resolved, so the application would never attempt to load additional layers. Now the system waits for each layer to finish loading completely (including fetching the STIX data and upgrading layers) before resolving so that the next layer can attempt to load.

Also updates the app version number to v4.5.2.