### PR TITLE
Fix/#373 system theme color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# Changes staged in develop
+
+## Fixes
+- Fixed inconsistencies within the ATT&CK Navigator dark theme.
+  - If the user switches from the dark/light theme to use the system's theme, the browser will remember to continue using the system theme until changed again.
+  - The layer upgrade feature now supports dark theme.
+
 # v4.5.1 - 21 October 2021
 
 ## Fixes

--- a/nav-app/src/app/cookies.ts
+++ b/nav-app/src/app/cookies.ts
@@ -48,7 +48,7 @@ const hasCookie = function(key: string): boolean {
  * @param {string} key to delete
  */
 const deleteCookie = function(key: string) {
-    document.cookie = key + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+  document.cookie = key + '=;expires=Thu, 01 Jan 1970 00:00:01 GMT;path=/;SameSite=Strict';
 }
 
 export {setCookie, getCookie, hasCookie, deleteCookie};


### PR DESCRIPTION
System theme color was not changing after setting theme color to dark/light (whichever is opposite of system theme), and switching back to use system settings.

Cookie deletion in HTTPS seems to need the exact same parameters as the ones it was set with, so the same `';path=/;SameSite=Strict'` parameters were added to cookie deletion method.

Tested out cookie removal at: https://iguannalin.github.io/attack-navigator/