### PR TITLE
Add support for alpha in gradients

### DIFF
--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -70,6 +70,20 @@ export abstract class Cell {
     }
 
     /**
+     * Emulate transparency without an alpha channel
+     * @param color color with alpha channel
+     * @returns color without an alpha channel which has been mixed with the proper background color as if it is transparent
+     */
+    private emulate_alpha(color: any, log=false) {
+        let cell_color = tinycolor(color.toHex8String())
+        let cell_color_alpha = cell_color.getAlpha();
+        // if (!cell_color_alpha) return color;
+        cell_color.setAlpha(1)
+        let result = tinycolor.mix(this.isDarkTheme ? "#2e2e3f" : "#ffffff", cell_color, cell_color_alpha * 100)
+        return result;
+    }
+
+    /**
      * Get most readable text color for the given technique
      * @param  technique     the technique to get the text color for
      * @param  antihighlight boolean, true if the column is not selected.
@@ -81,9 +95,9 @@ export abstract class Cell {
         if (!tvm.enabled) return "rgb(255 255 255 / 25%)";
         // don't display if disabled or highlighted
         // if (this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_tactic_union_id == this.technique.technique_tactic_union_id) return "black"
-        if (tvm.color) return tinycolor.mostReadable(tvm.color, ["white", "black"]);
-        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor) return tinycolor.mostReadable(tvm.aggregateScoreColor, ["white", "black"]);
-        if (tvm.score && !isNaN(Number(tvm.score))) return tinycolor.mostReadable(tvm.scoreColor, ["white", "black"]);
+        if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]); 
+        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
+        if (tvm.score && !isNaN(Number(tvm.score))) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
         else return this.isDarkTheme ? "white" : "black";
     }
 
@@ -109,9 +123,9 @@ export abstract class Cell {
         let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic)
         // don't display if disabled or highlighted
         if (!tvm.enabled || this.isHighlighted) return null;
-        if (tvm.color) return { "background": tvm.color }
-        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore))) return { "background": tvm.aggregateScoreColor }
-        if (tvm.score) return { "background": tvm.scoreColor }
+        if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
+        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore))) return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
+        if (tvm.score) return { "background": this.emulate_alpha(tvm.scoreColor, true) }
         // return tvm.enabled && tvm.score && !tvm.color && !(this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_id == technique.technique_id)
     }
 }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -125,7 +125,7 @@ export abstract class Cell {
         if (!tvm.enabled || this.isHighlighted) return null;
         if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
         if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore))) return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
-        if (tvm.score) return { "background": this.emulate_alpha(tvm.scoreColor, true) }
+        if (tvm.score) return { "background": this.emulate_alpha(tvm.scoreColor) }
         // return tvm.enabled && tvm.score && !tvm.color && !(this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_id == technique.technique_id)
     }
 }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -74,7 +74,7 @@ export abstract class Cell {
      * @param color color with alpha channel
      * @returns color without an alpha channel which has been mixed with the proper background color as if it is transparent
      */
-    private emulate_alpha(color: any, log=false) {
+    private emulate_alpha(color: any) {
         let cell_color = tinycolor(color.toHex8String())
         let cell_color_alpha = cell_color.getAlpha();
         // if (!cell_color_alpha) return color;

--- a/nav-app/src/app/viewmodels.service.ts
+++ b/nav-app/src/app/viewmodels.service.ts
@@ -224,7 +224,7 @@ export class Gradient {
         let colorList: string[] = [];
         let self = this;
         this.colors.forEach(function(gColor: Gcolor) {
-            let hexstring = (tinycolor(gColor.color).toHexString())
+            let hexstring = (tinycolor(gColor.color).toHex8String()); // include the alpha channel
             colorList.push(hexstring)
         });
 


### PR DESCRIPTION
Patch for #375.

- Updates the cell color and cell text color code to emulate an alpha channel on non hex8 formatted colors
- Updates the gradient serialization code to save hex8 formatted colors in exported gradients (otherwise alpha would not be saved in exported gradients).

Test layer using alpha gradients:
```json
{
	"name": "layer",
	"versions": {
		"attack": "10",
		"navigator": "4.5.1",
		"layer": "4.2"
	},
	"domain": "enterprise-attack",
	"description": "",
	"filters": {
		"platforms": [
			"Linux",
			"macOS",
			"Windows",
			"Azure AD",
			"Office 365",
			"SaaS",
			"IaaS",
			"Google Workspace",
			"PRE",
			"Network",
			"Containers"
		]
	},
	"sorting": 0,
	"layout": {
		"layout": "side",
		"aggregateFunction": "average",
		"showID": false,
		"showName": true,
		"showAggregateScores": false,
		"countUnscored": false
	},
	"hideDisabled": false,
	"techniques": [
		{
			"techniqueID": "T1190",
			"tactic": "initial-access",
			"score": 0,
			"color": "",
			"comment": "",
			"enabled": true,
			"metadata": [],
			"showSubtechniques": false
		},
		{
			"techniqueID": "T1133",
			"tactic": "persistence",
			"score": 0.5,
			"color": "",
			"comment": "",
			"enabled": true,
			"metadata": [],
			"showSubtechniques": false
		},
		{
			"techniqueID": "T1133",
			"tactic": "initial-access",
			"score": 0.5,
			"color": "",
			"comment": "",
			"enabled": true,
			"metadata": [],
			"showSubtechniques": false
		},
		{
			"techniqueID": "T1200",
			"tactic": "initial-access",
			"score": 1,
			"color": "",
			"comment": "",
			"enabled": true,
			"metadata": [],
			"showSubtechniques": false
		}
	],
	"gradient": {
		"colors": [
			"#00000000",
			"#00ff00ff"
		],
		"minValue": 0,
		"maxValue": 1
	},
	"legendItems": [],
	"metadata": [],
	"showTacticRowBackground": false,
	"tacticRowBackground": "#dddddd",
	"selectTechniquesAcrossTactics": true,
	"selectSubtechniquesWithParent": false
}
```