### PR TITLE
Fixed incorrect technique cell background color when aggregate score is an empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
     The creation of the tag can be disabled with the --no-git-tag-version if desired.
 -->
 
+# v4.5.4 - 15 November 2021
+## Fixes
+- Fixed a bug where layers with aggregate scores enabled would be render a black background on techniques which have no aggregate score. See issue [#388](https://github.com/mitre-attack/attack-navigator/issues/388).
+
 # v4.5.3 - 12 November 2021
 
 ## Fixes

--- a/nav-app/package-lock.json
+++ b/nav-app/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "attack-navigator",
-  "version": "4.5.3",
+  "version": "4.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/nav-app/package.json
+++ b/nav-app/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/mitre-attack/attack-navigator.git"
   },
-  "version": "4.5.3",
+  "version": "4.5.4",
   "license": "Apache-2.0",
   "scripts": {
     "ng": "ng",

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -85,7 +85,7 @@ export abstract class Cell {
          *
          * Therefore y must be cloned after it is constructed to avoid transformations of x affecting it.
          * In this context, the color arg must be cloned because
-         * in some contexts it is a tinycolor and we change its alpha below, 
+         * in some contexts it is a tinycolor and we change its alpha below,
          * which could affect the copy in the calling function
          */
         let cell_color = tinycolor(color).clone();
@@ -107,7 +107,7 @@ export abstract class Cell {
         if (!tvm.enabled) return this.isDarkTheme ? "rgb(255 255 255 / 25%)" : "#aaaaaa";
         // don't display if disabled or highlighted
         // if (this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_tactic_union_id == this.technique.technique_tactic_union_id) return "black"
-        if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]); 
+        if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]);
         if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
         if (tvm.score && !isNaN(Number(tvm.score))) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
         else return this.isDarkTheme ? "white" : "black";
@@ -136,7 +136,7 @@ export abstract class Cell {
         // don't display if disabled or highlighted
         if (!tvm.enabled || this.isHighlighted) return null;
         if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
-        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore))) return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
+        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0) return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
         if (tvm.score) return { "background": this.emulate_alpha(tvm.scoreColor) }
         // return tvm.enabled && tvm.score && !tvm.color && !(this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_id == technique.technique_id)
     }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -88,6 +88,7 @@ export abstract class Cell {
          * in some contexts it is a tinycolor and we change its alpha below,
          * which could affect the copy in the calling function
          */
+        if (!color || color.length < 1) return "";
         let cell_color = tinycolor(color).clone();
         let cell_color_alpha = cell_color.getAlpha();
         cell_color.setAlpha(1)


### PR DESCRIPTION
Fixes #388 where unscored techniques (when show aggregate scores is enabled) would have a black background color, making it hard to see in the light color theme