### PR TITLE
Consistent font sizes for SVG export

### DIFF
--- a/nav-app/src/app/exporter/exporter.component.ts
+++ b/nav-app/src/app/exporter/exporter.component.ts
@@ -460,7 +460,7 @@ export class ExporterComponent implements OnInit {
                     contentGroup.append("text")
                         .text(subsectionContent)
                         .attr("font-size", function() {
-                            return optimalFontSize(subsectionContent.data as string, this, boxContentWidth, boxGroupY.bandwidth(), false, 32)
+                            return optimalFontSize(subsectionContent.data as string, this, boxContentWidth, boxGroupY.bandwidth(), false, 12)
                         })
                         .each(function() { centerValign(this); })
                         // .attr("dominant-baseline", "middle")

--- a/nav-app/src/app/exporter/exporter.component.ts
+++ b/nav-app/src/app/exporter/exporter.component.ts
@@ -651,14 +651,20 @@ export class ExporterComponent implements OnInit {
         // 888o     oo 888          888   888           888    888           o88 88o    888   
         //  888oooo88    88oooo888 o888o o888o         o888o     88oooo888 o88o   o88o   888o 
                                                                                            
-        
+        // Track the smallest optimal technique/subtechnique font size
+        let minCellTextSize = Infinity;
 
         techniqueGroups.append("text")
             .text(function(technique: RenderableTechnique) { 
                 return technique.text;
             })
             .attr("font-size", function(technique: RenderableTechnique) {
-                return optimalFontSize(technique.text, this, x.bandwidth(), y(1), false);
+                const fontSize = optimalFontSize(technique.text, this, x.bandwidth(), y(1), false);
+                // Track the smallest font size found
+                if (fontSize < minCellTextSize) {
+                    minCellTextSize = fontSize;
+                }
+                return fontSize
             })
             // .attr("dominant-baseline", "middle")
             .each(function() { centerValign(this); })
@@ -669,12 +675,24 @@ export class ExporterComponent implements OnInit {
                 return subtechnique.text;
             })
             .attr("font-size", function(subtechnique: RenderableTechnique) {
-                return optimalFontSize(subtechnique.text, this, x.bandwidth() - subtechniqueIndent, y(1), false);
+                const fontSize = optimalFontSize(subtechnique.text, this, x.bandwidth() - subtechniqueIndent, y(1), false);
+                // Track the smallest font size found
+                if (fontSize < minCellTextSize) {
+                    minCellTextSize = fontSize;
+                }
+                return fontSize
             })
             // .attr("dominant-baseline", "middle")
             .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.textColor; })
             .each(function() { centerValign(this); })
     
+        // Set technique and subtechnique groups to the same font size
+        techniqueGroups.select("text").attr("font-size", minCellTextSize)
+        subtechniqueGroups.select("text").attr("font-size", minCellTextSize)
+
+        // Track the smallest optimal tactic label font size
+        let minTacticLabelTextSize = Infinity;
+
         let tacticLabels = tacticGroups.append("g")
             .attr("class", "tactic-label");
         tacticLabels.append("text")
@@ -682,7 +700,12 @@ export class ExporterComponent implements OnInit {
                 return tactic.tactic.name;
             })
             .attr("font-size", function(tactic: RenderableTactic) {
-                return optimalFontSize(tactic.tactic.name, this, x.bandwidth(), y(1), true);
+                const fontSize = optimalFontSize(tactic.tactic.name, this, x.bandwidth(), y(1), true);
+                // Track the smallest font size found
+                if (fontSize < minTacticLabelTextSize) {
+                    minTacticLabelTextSize = fontSize;
+                }
+                return fontSize
             })
             // .attr("dominant-baseline", "middle")
             .attr("fill", function(tactic: RenderableTactic) {
@@ -691,6 +714,9 @@ export class ExporterComponent implements OnInit {
             })
             .attr("font-weight", "bold")
             .each(function() { centerValign(this); })
+
+        // Set tactic labels to same font size
+        tacticLabels.select("text").attr("font-size", minTacticLabelTextSize)
 
         //ooooo  oooo                  oooo                       oooo                         oooo      ooooo                                                            oooo 
         // 888    88 oo oooooo    ooooo888   ooooooo     ooooooo   888  ooooo ooooooooo8  ooooo888        888         ooooooooo8   oooooooo8 ooooooooo8 oo oooooo    ooooo888  


### PR DESCRIPTION
## Summary

Addresses #221 by setting 
- Cell text, i.e. technique/subtechnique names, to the same minimum optimal font size
- Tactic labels have their own consistent minimum optimal font size
- Header text max size is now 12 instead of 32 to better match the rest of the font sizes, open to thoughts

Use case: looking to have a consistent custom matrix representation for inclusion in a paper/poster.

## Results

Screenshot of SVG export of the default enterprise layer on this branch:
![enterprise-layer-211-fix](https://user-images.githubusercontent.com/1416347/146275834-251a51b9-555b-4494-8967-033ed9f4bbc7.png)

Compared to existing output:

Screenshot of SVG export of the default enterprise layer on `develop`:
![enterprise-layer-develop](https://user-images.githubusercontent.com/1416347/146275828-80f348f8-b2a9-4308-9fd4-d332e6d02cf4.png)


