### PR TITLE
Break-up lines in technique cell tooltip to prevent overflow outside of tooltip box

### DIFF
--- a/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.scss
+++ b/nav-app/src/app/matrix/technique-cell/tooltip/tooltip.component.scss
@@ -10,6 +10,7 @@
         td {
             padding: 3px;
             vertical-align: top;
+            white-space: pre-line !important;
         }
         td:first-child {
             white-space: nowrap;


### PR DESCRIPTION
Addresses #359 