### PR TITLE
497 running error step 811 run npm install unsafe perm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /src/nav-app
 RUN chown -R node:node ./
 
 # install packages and build 
-RUN npm install --unsafe-perm
+RUN npm install --unsafe-perm --legacy-peer-deps
 
 EXPOSE 4200
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,12 @@ RUN chown -R node:node ./
 # install packages and build 
 RUN npm install --unsafe-perm --legacy-peer-deps
 
+# NOTE on legacy-peer-deps:
+# The --legacy-peer-deps flags is included to bypass the dependency peer resolution conflict that arises between Angular
+# and @angular-devkit/build-angular@0.1100.7, the latter of which has peerDependency: karma: '~5.1.0'. However,
+# upgrading karma to 5.1.0 cascades into a litany of other dependency conflicts, which would ultimately require us to
+# upgrade from Angular v11 to v12. Therefore, legacy-peer-deps will be allowed until a major framework upgrade can occur
+
 EXPOSE 4200
 
 CMD npm start


### PR DESCRIPTION
Closes #497 

# Explanation

This Issue is triggered by package dependency `@angular-devkit/build-angular@0.1100.7`. 

```
npm ERR! Conflicting peer dependency: karma@5.1.1
npm ERR! node_modules/karma
npm ERR!   peerOptional karma@"~5.1.0" from @angular-devkit/build-angular@0.1100.7
```

If we check the peer dependencies of `@angular-devkit/build-angular@0.1100.7`:

```
➜npm info @angular-devkit/build-angular@0.1100.7 peerDependencies
{
  '@angular/compiler-cli': '^11.0.0',
  '@angular/localize': '^11.0.0',
  karma: '~5.1.0',  <--- HERE IS THE CONFLICT
  'ng-packagr': '^11.0.0',
  protractor: '^7.0.0',
  tslint: '^6.1.0',
  typescript: '~4.0.0'
}
```

However, upgrading `karma` to 5.1.0 is currently impossible on `@angular/core@11.2.14`. We would need to upgrade to version 12 for this to work.

```
➜npm install karma@~5.1.0 --save-dev                             
npm ERR! code ERESOLVE
npm ERR! ERESOLVE could not resolve
npm ERR! 
npm ERR! While resolving: @angular/http@7.2.16
npm ERR! Found: @angular/core@11.2.14
npm ERR! node_modules/@angular/core
npm ERR!   peer @angular/core@"11.2.14" from @angular/animations@11.2.14
npm ERR!   node_modules/@angular/animations
npm ERR!     peer @angular/animations@"^11.0.0 || ^12.0.0-0" from @angular/material@11.2.13
npm ERR!     node_modules/@angular/material
npm ERR!       @angular/material@"^11.0.2" from the root project
npm ERR!     peerOptional @angular/animations@"11.2.14" from @angular/platform-browser@11.2.14
npm ERR!     node_modules/@angular/platform-browser
npm ERR!       peer @angular/platform-browser@"11.2.14" from @angular/forms@11.2.14
npm ERR!       node_modules/@angular/forms
npm ERR!         peer @angular/forms@"^11.0.0 || ^12.0.0-0" from @angular/material@11.2.13
npm ERR!         node_modules/@angular/material
npm ERR!         2 more (ngx-color-picker, the root project)
npm ERR!       3 more (@angular/platform-browser-dynamic, @angular/router, the root project)
npm ERR!     1 more (the root project)
npm ERR!   peer @angular/core@"^11.0.0 || ^12.0.0-0" from @angular/cdk@11.2.13
npm ERR!   node_modules/@angular/cdk
npm ERR!     peer @angular/cdk@"11.2.13" from @angular/material@11.2.13
npm ERR!     node_modules/@angular/material
npm ERR!       @angular/material@"^11.0.2" from the root project
npm ERR!     @angular/cdk@"^11.0.2" from the root project
npm ERR!   9 more (@angular/common, @angular/forms, @angular/material, ...)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer @angular/core@"7.2.16" from @angular/http@7.2.16
npm ERR! node_modules/@angular/http
npm ERR!   @angular/http@"^7.2.16" from the root project
npm ERR! 
npm ERR! Conflicting peer dependency: @angular/core@7.2.16
```

Therefore, the simplest solution (for now) is to bypass installing peer dependencies via the `--legacy-peer-deps` flag. It disables peerDependency auto-installation and proceeds with the installation anyway.