### PR TITLE
Ignore a matrix's references to tactics that aren't in the source content

### DIFF
--- a/nav-app/src/app/data.service.ts
+++ b/nav-app/src/app/data.service.ts
@@ -497,7 +497,10 @@ export class Matrix extends BaseStix {
      */
     constructor(stixSDO: any, idToTacticSDO: Map<string, any>, techniques: Technique[], dataService: DataService) {
         super(stixSDO, dataService);
-        this.tactics = stixSDO.tactic_refs.map((tacticID) => new Tactic(idToTacticSDO.get(tacticID), techniques, this.dataService))
+        this.tactics = stixSDO.tactic_refs
+          .map(tacticID => idToTacticSDO.get(tacticID))  // Get tacticSDOs
+          .filter(tacticSDO => tacticSDO)                // Filter out nulls (tacticSDO not found)
+          .map(tacticSDO => new Tactic(tacticSDO, techniques, this.dataService));  // Create Tactic objects
     }
 }
 


### PR DESCRIPTION
When creating a Matrix object, filters out references to tactics that aren't included in the source content.