### PR TITLE
Add additional color options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@
     The creation of the tag can be disabled with the --no-git-tag-version if desired.
 -->
 
+# Changes Staged on Develop
+
+## New Features
+- Users can disable the background color effect on manually assigned colors, aggregate scores, or non-aggregate scores by editing `src/assets/config.json` or through the "Create Customized Navigator" interface. See issue [#371](https://github.com/mitre-attack/attack-navigator/issues/371).
+
 # 4.8.0 - 20 December 2022
 
 ## New Features

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -113,7 +113,7 @@ export abstract class Cell {
         // don't display if disabled or highlighted
         // if (this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_tactic_union_id == this.technique.technique_tactic_union_id) return "black"
         if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]);
-        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor && this.configService.getFeature('aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
+        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor && !this.technique.isSubtechnique && this.configService.getFeature('aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
         if (tvm.score && !isNaN(Number(tvm.score)) && this.configService.getFeature('non_aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
         else return this.isDarkTheme ? "white" : "black";
     }
@@ -158,7 +158,7 @@ export abstract class Cell {
         // don't display if disabled or highlighted
         if (!tvm.enabled || this.isHighlighted) return null;
         if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
-        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0 && this.configService.getFeature('aggregate_score_color')) {
+        if (this.viewModel.layout.showAggregateScores && !this.technique.isSubtechnique && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0 && this.configService.getFeature('aggregate_score_color')) {
             return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
         }
         if (tvm.score && this.configService.getFeature('non_aggregate_score_color')) return { "background": this.emulate_alpha(tvm.scoreColor) }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -107,7 +107,7 @@ export abstract class Cell {
      * @return               black, white, or gray, depending on technique and column state
      */
     public getTechniqueTextColor() {
-        if (!this.tactic) return this.isDarkTheme ? "white" : "black";
+        if (!this.tactic || !this.configService.getFeature('background_color')) return this.isDarkTheme ? "white" : "black";
         let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic)
         if (!tvm.enabled) return this.isDarkTheme ? "rgb(255 255 255 / 25%)" : "#aaaaaa";
         // don't display if disabled or highlighted
@@ -156,7 +156,7 @@ export abstract class Cell {
         if (!this.tactic) return null;
         let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic)
         // don't display if disabled or highlighted
-        if (!tvm.enabled || this.isHighlighted) return null;
+        if (!tvm.enabled || this.isHighlighted || !this.configService.getFeature('background_color')) return null;
         if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
         if (this.viewModel.layout.showAggregateScores && !this.technique.isSubtechnique && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0 && this.configService.getFeature('aggregate_score_color')) {
             return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -113,8 +113,8 @@ export abstract class Cell {
         // don't display if disabled or highlighted
         // if (this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_tactic_union_id == this.technique.technique_tactic_union_id) return "black"
         if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]);
-        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
-        if (tvm.score && !isNaN(Number(tvm.score))) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
+        if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor && this.configService.getFeature('aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
+        if (tvm.score && !isNaN(Number(tvm.score)) && this.configService.getFeature('non_aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
         else return this.isDarkTheme ? "white" : "black";
     }
 
@@ -158,8 +158,10 @@ export abstract class Cell {
         // don't display if disabled or highlighted
         if (!tvm.enabled || this.isHighlighted) return null;
         if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
-        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0) return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
-        if (tvm.score) return { "background": this.emulate_alpha(tvm.scoreColor) }
+        if (this.viewModel.layout.showAggregateScores && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0 && this.configService.getFeature('aggregate_score_color')) {
+            return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
+        }
+        if (tvm.score && this.configService.getFeature('non_aggregate_score_color')) return { "background": this.emulate_alpha(tvm.scoreColor) }
         // return tvm.enabled && tvm.score && !tvm.color && !(this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_id == technique.technique_id)
     }
 }

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -107,12 +107,12 @@ export abstract class Cell {
      * @return               black, white, or gray, depending on technique and column state
      */
     public getTechniqueTextColor() {
-        if (!this.tactic || !this.configService.getFeature('background_color')) return this.isDarkTheme ? "white" : "black";
+        if (!this.tactic) return this.isDarkTheme ? "white" : "black";
         let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic)
         if (!tvm.enabled) return this.isDarkTheme ? "rgb(255 255 255 / 25%)" : "#aaaaaa";
         // don't display if disabled or highlighted
         // if (this.viewModel.highlightedTechnique && this.viewModel.highlightedTechnique.technique_tactic_union_id == this.technique.technique_tactic_union_id) return "black"
-        if (tvm.color) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]);
+        if (tvm.color && this.configService.getFeature('background_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.color), ["white", "black"]);
         if (this.viewModel.layout.showAggregateScores && tvm.aggregateScoreColor && !this.technique.isSubtechnique && this.configService.getFeature('aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.aggregateScoreColor), ["white", "black"]);
         if (tvm.score && !isNaN(Number(tvm.score)) && this.configService.getFeature('non_aggregate_score_color')) return tinycolor.mostReadable(this.emulate_alpha(tvm.scoreColor), ["white", "black"]);
         else return this.isDarkTheme ? "white" : "black";
@@ -156,8 +156,8 @@ export abstract class Cell {
         if (!this.tactic) return null;
         let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic)
         // don't display if disabled or highlighted
-        if (!tvm.enabled || this.isHighlighted || !this.configService.getFeature('background_color')) return null;
-        if (tvm.color) return { "background": this.emulate_alpha(tvm.color) }
+        if (!tvm.enabled || this.isHighlighted) return null;
+        if (tvm.color && this.configService.getFeature('background_color')) return { "background": this.emulate_alpha(tvm.color) }
         if (this.viewModel.layout.showAggregateScores && !this.technique.isSubtechnique && !isNaN(Number(tvm.aggregateScore)) && tvm.aggregateScore.length > 0 && this.configService.getFeature('aggregate_score_color')) {
             return { "background": this.emulate_alpha(tvm.aggregateScoreColor) }
         }

--- a/nav-app/src/assets/config.json
+++ b/nav-app/src/assets/config.json
@@ -211,6 +211,7 @@
         {"name": "technique_controls", "enabled": true, "description": "Disable to disable all subfeatures", "subfeatures": [
             {"name": "disable_techniques", "enabled": true, "description": "Disable to remove the ability to disable techniques."},
             {"name": "manual_color", "enabled": true, "description": "Disable to remove the ability to assign manual colors to techniques."},
+            {"name": "background_color", "enabled": true, "description": "Disable to remove the background color effect on techniques."},
             {"name": "non_aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on non-aggregate scores."},
             {"name": "aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on aggregate scores."},
             {"name": "scoring", "enabled": true, "description": "Disable to remove the ability to score techniques."},

--- a/nav-app/src/assets/config.json
+++ b/nav-app/src/assets/config.json
@@ -211,7 +211,7 @@
         {"name": "technique_controls", "enabled": true, "description": "Disable to disable all subfeatures", "subfeatures": [
             {"name": "disable_techniques", "enabled": true, "description": "Disable to remove the ability to disable techniques."},
             {"name": "manual_color", "enabled": true, "description": "Disable to remove the ability to assign manual colors to techniques."},
-            {"name": "background_color", "enabled": true, "description": "Disable to remove the background color effect on techniques."},
+            {"name": "background_color", "enabled": true, "description": "Disable to remove the background color effect on manually assigned colors."},
             {"name": "non_aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on non-aggregate scores."},
             {"name": "aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on aggregate scores."},
             {"name": "scoring", "enabled": true, "description": "Disable to remove the ability to score techniques."},

--- a/nav-app/src/assets/config.json
+++ b/nav-app/src/assets/config.json
@@ -211,6 +211,8 @@
         {"name": "technique_controls", "enabled": true, "description": "Disable to disable all subfeatures", "subfeatures": [
             {"name": "disable_techniques", "enabled": true, "description": "Disable to remove the ability to disable techniques."},
             {"name": "manual_color", "enabled": true, "description": "Disable to remove the ability to assign manual colors to techniques."},
+            {"name": "non_aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on non-aggregate scores."},
+            {"name": "aggregate_score_color", "enabled": true, "description": "Disable to remove the color effect on aggregate scores."},
             {"name": "scoring", "enabled": true, "description": "Disable to remove the ability to score techniques."},
             {"name": "comments", "enabled": true, "description": "Disable to remove the ability to add comments to techniques."},
             {"name": "comment_underline", "enabled": true, "description": "Disable to remove the comment underline effect on techniques."},


### PR DESCRIPTION
Adds the following three color options to "create a customized navigator"  technique controls.

- Enable/disable displaying colors for aggregate scores
- Enable/disable displaying colors for non-aggregate scores
- Enable/disable displaying manually assigned colors

Resolves [#371](https://github.com/mitre-attack/attack-navigator/issues/371)