### PR TITLE
SVG toolbar dark mode colors

### DIFF
--- a/nav-app/src/app/exporter/exporter.component.html
+++ b/nav-app/src/app/exporter/exporter.component.html
@@ -61,7 +61,7 @@
                                        [disabled]="!config.showHeader"
                                        [(ngModel)]="config.headerHeight"
                                        (input)="buildSVG()" />
-                                <span matSuffix [style.color]="!config.showHeader ? 'rgba(0,0,0,0.42)' : 'black'">{{config.unit}}</span>
+                                <span matSuffix>{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                     </ul>

--- a/nav-app/src/app/exporter/exporter.component.html
+++ b/nav-app/src/app/exporter/exporter.component.html
@@ -61,7 +61,7 @@
                                        [disabled]="!config.showHeader"
                                        [(ngModel)]="config.headerHeight"
                                        (input)="buildSVG()" />
-                                <span matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': !config.showHeader}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                     </ul>

--- a/nav-app/src/app/exporter/exporter.component.html
+++ b/nav-app/src/app/exporter/exporter.component.html
@@ -115,7 +115,7 @@
                                        step="1"
                                        [(ngModel)]="config.legendX"
                                        (input)="buildSVG()" />
-                                <span [style.color]="config.legendDocked ? 'rgba(0,0,0,0.42)' : 'black'" matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.legendDocked}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                         <li>
@@ -128,7 +128,7 @@
                                        step="1"
                                        [(ngModel)]="config.legendY"
                                        (input)="buildSVG()" />
-                                <span [style.color]="config.legendDocked ? 'rgba(0,0,0,0.42)' : 'black'" matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.legendDocked}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                         <li>
@@ -141,7 +141,7 @@
                                        step="1"
                                        [(ngModel)]="config.legendWidth"
                                        (input)="buildSVG()" />
-                                <span [style.color]="config.legendDocked ? 'rgba(0,0,0,0.42)' : 'black'" matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.legendDocked}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                         <li>
@@ -154,7 +154,7 @@
                                        step="1"
                                        [(ngModel)]="config.legendHeight"
                                        (input)="buildSVG()" />
-                                <span [style.color]="config.legendDocked ? 'rgba(0,0,0,0.42)' : 'black'" matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.legendDocked}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                     </ul>

--- a/nav-app/src/styles.scss
+++ b/nav-app/src/styles.scss
@@ -215,6 +215,10 @@ body {
           @include adaptive-color-dark-only("color", rgba(255, 255, 255, 0.9));
         }
 
+        .mat-select-arrow {
+          @include adaptive-color-dark-only("color", rgba(255, 255, 255, 0.9));
+        }
+
         .disabled-text {
           @include adaptive-color("color", rgba(0,0,0,.38), color(dark-disabled));
         }

--- a/nav-app/src/styles.scss
+++ b/nav-app/src/styles.scss
@@ -210,6 +210,10 @@ body {
           @include adaptive-color-dark-only("background-color", transparent);
           @include adaptive-color-dark-only("background-image", linear-gradient(to right, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.7) 33%, transparent 0%));
         }
+        
+        .mat-select-value {
+          @include adaptive-color-dark-only("color", rgba(255, 255, 255, 0.9));
+        }
       }
 
     }

--- a/nav-app/src/styles.scss
+++ b/nav-app/src/styles.scss
@@ -210,9 +210,13 @@ body {
           @include adaptive-color-dark-only("background-color", transparent);
           @include adaptive-color-dark-only("background-image", linear-gradient(to right, rgba(255, 255, 255, 0.9) 0%, rgba(255, 255, 255, 0.7) 33%, transparent 0%));
         }
-        
+
         .mat-select-value {
           @include adaptive-color-dark-only("color", rgba(255, 255, 255, 0.9));
+        }
+
+        .disabled-text {
+          @include adaptive-color("color", rgba(0,0,0,.38), color(dark-disabled));
         }
       }
 


### PR DESCRIPTION
When using Navigator in dark mode, under "render layer to SVG", "image size", the unit suffix for "header height" is black. Additionally, the placeholder text for all the dropdown menus under "render layer to SVG" are black (font, sub-techniques, etc.). This changes their colors to white to match the styling of the rest of the toolbar. 