### PR TITLE
SVG size and orientation options

### DIFF
--- a/nav-app/src/app/exporter/exporter.component.html
+++ b/nav-app/src/app/exporter/exporter.component.html
@@ -29,14 +29,35 @@
                     <ul>
                         <li>
                             <mat-form-field>
+                                <mat-select placeholder="orientation" [(ngModel)]="config.orientation" (selectionChange)="buildSVG()">
+                                    <mat-option value="portrait">Portrait</mat-option>
+                                    <mat-option value="landscape">Landscape</mat-option>
+                                </mat-select>
+                            </mat-form-field>
+                        </li>
+                        <li>
+                            <mat-form-field>
+                                <mat-select matSelect placeholder="size" [(ngModel)]="config.size" (selectionChange)="buildSVG()">
+                                    <mat-option value="custom">Custom</mat-option>
+                                    <mat-option value="letter">US Letter: 8.5x11</mat-option>
+                                    <mat-option value="legal">US Legal: 8.5x14</mat-option>
+                                    <mat-option value="small">Small: 11x17</mat-option>
+                                    <mat-option value="medium">Medium: 18x24</mat-option>
+                                    <mat-option value="large">Large 24x36</mat-option>
+                                </mat-select>
+                            </mat-form-field>
+                        </li>
+                        <li>
+                            <mat-form-field>
                                 <input matInput
                                        class="has-suffix"
                                        type="number"
                                        placeholder="width"
                                        step="0.01"
+                                       [disabled]="config.size !== 'custom'"
                                        [(ngModel)]="config.width"
                                        (input)="buildSVG()" />
-                                <span matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.size !== 'custom'}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                         <li>
@@ -46,9 +67,10 @@
                                        type="number"
                                        placeholder="height"
                                        step="0.01"
+                                       [disabled]="config.size !== 'custom'"
                                        [(ngModel)]="config.height"
                                        (input)="buildSVG()" />
-                                <span matSuffix>{{config.unit}}</span>
+                                <span matSuffix [ngClass]="{'disabled-text': config.size !== 'custom'}">{{config.unit}}</span>
                             </mat-form-field>
                         </li>
                         <li>

--- a/nav-app/src/app/exporter/exporter.component.ts
+++ b/nav-app/src/app/exporter/exporter.component.ts
@@ -35,7 +35,7 @@ export class ExporterComponent implements OnInit {
 
             "unit": "in",
             "orientation": "landscape",
-            "size": "custom",
+            "size": "letter",
 
             "showSubtechniques": "expanded",
 

--- a/nav-app/src/app/exporter/exporter.component.ts
+++ b/nav-app/src/app/exporter/exporter.component.ts
@@ -34,6 +34,8 @@ export class ExporterComponent implements OnInit {
             "headerHeight": 1,
 
             "unit": "in",
+            "orientation": "landscape",
+            "size": "custom",
 
             "showSubtechniques": "expanded",
 
@@ -131,6 +133,8 @@ export class ExporterComponent implements OnInit {
         self.buildSVGDebounce = false;
 
         console.log("building SVG");
+
+        setSize(self.config.size, self.config.orientation)
 
         //check preconditions, make sure they're in the right range
         let margin = {top: 5, right: 5, bottom: 5, left: 5};
@@ -473,6 +477,27 @@ export class ExporterComponent implements OnInit {
                     .attr("y1", boxGroupY.bandwidth())
                     .attr("y2", boxGroupY.bandwidth())
                     .attr("stroke", "#dddddd");
+            }
+        }
+
+        /**
+         * Function to set width and height based on selected size and orientaiton
+         * @param {string} size dimensions
+         * @param {string} orientation  portrait or landscape
+         */
+        function setSize(size, orientation) {
+            const ratioMap = {
+                letter: {portrait: [8.5, 11], landscape: [11, 8.5]},
+                legal: {portrait: [8.5, 14], landscape: [14, 8.5]},
+                small: {portrait: [11, 17], landscape: [17, 11]},
+                medium: {portrait: [18, 24], landscape: [24, 18]},
+                large: {portrait: [24, 36], landscape: [36, 24]},
+            };
+
+            if (size !== "custom") {
+                const [w, h] = ratioMap[size][orientation];
+                self.config.width = w;
+                self.config.height = h;
             }
         }
 


### PR DESCRIPTION
Added two additional image size options in the "render layer to SVG" toolbar. Users can select from a variety of different svg size options, including "custom" and can set the size to either "landscape" or "portrait". 