### PR TITLE
Update Node.js 16 to 18 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # Build stage
 
-FROM node:16
+FROM node:18
+
+ENV NODE_OPTIONS=--openssl-legacy-provider
 
 WORKDIR /src
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Use our [GitHub Issue Tracker](https://github.com/mitre-attack/attack-navigator/
 
 ## Requirements
 
-* [Node.js](https://nodejs.org) version 8 or greater
+* [Node.js](https://nodejs.org) version 18 or greater
 * [AngularCLI](https://cli.angular.io)
 
 ## Supported Browsers


### PR DESCRIPTION
Node.js 16 has now reached maintenance mode and will reach end-of-life on 2023-09-11. The new LTS version is Node.js 18. Updates the Dockerfile to use Node.js 18.

Resolves https://github.com/mitre-attack/attack-navigator/issues/540