### PR TITLE
Updated Download/Export Feature

### DIFF
--- a/nav-app/src/app/datatable/data-table.component.html
+++ b/nav-app/src/app/datatable/data-table.component.html
@@ -141,36 +141,65 @@ o888     88 o888   888o 8888o  88  88  888  88  888    888 o888   888o 888      
                  </div>
              </div>
 
-
-
-            <!-- save locally as JSON -->
-            <div *ngIf="configService.getFeature('download_layer')" class="control-row-item">
-                <div class="control-row-button noselect"
-                     (click)="saveLayerLocally()"
-                     matTooltipPosition="below"
-                     matTooltip="download layer as json">
-                    <span class="material-icons" alt="save layer">file_download</span>
+             <!-- export, save, and render features -->
+             <div *ngIf="configService.getFeature('download_layer')" class="control-row-item">
+                <div class="control-row-button dropdown noselect"
+                    (click)="handleExportDropdown()"
+                    matTooltipPosition="below"
+                    matTooltip="export">
+                    <span class="material-icons" alt="export">file_download</span>
                 </div>
-            </div>
+                <div class="dropdown-container select_behavior" #dropdown [class.left]="checkalign(dropdown)"
+                *ngIf="currentDropdown === 'export'">
+                    <div>
+                        <b class="filter-label">Export</b>
+                    </div>
+                    <div>
+                        <!-- save locally as JSON -->
+                        <div *ngIf="configService.getFeature('download_layer')" class="control-row-item">
+                            <div class="control-row-button noselect"
+                                (click)="saveLayerLocally()"
+                                matTooltipPosition="below"
+                                matTooltip="download layer as json">
+                                <span class="material-icons" alt="save layer">code</span>
+                            </div>
+                        </div>
 
-            <!-- export to excel -->
-            <div *ngIf="configService.getFeature('export_excel')" class="control-row-item">
-                <div class="control-row-button noselect"
-                     (click)="saveLayerLocallyExcel()"
-                     matTooltipPosition="below"
-                     matTooltip="export to excel">
-                    <span class="material-icons" alt="save layer">grid_on</span>
-                </div>
-            </div>
-
-
-            <!-- render layer to SVG -->
-            <div *ngIf="configService.getFeature('export_render')" class="control-row-item">
-                <div class="control-row-button noselect"
-                     (click)="exportRender()"
-                     matTooltipPosition="below"
-                     matTooltip="render layer to SVG">
-                    <span class="material-icons" alt="export render">camera_alt</span>
+                        <!-- export to excel -->
+                        <div *ngIf="configService.getFeature('export_excel')" class="control-row-item">
+                            <div class="control-row-button noselect"
+                                (click)="saveLayerLocallyExcel()"
+                                matTooltipPosition="below"
+                                matTooltip="export to excel">
+                                <span class="material-icons" alt="save layer">grid_on</span>
+                            </div>
+                        </div>
+                        <!-- render layer to SVG -->
+                        <div *ngIf="configService.getFeature('export_render')" class="control-row-item">
+                            <div class="control-row-button noselect"
+                                (click)="exportRender()"
+                                matTooltipPosition="below"
+                                matTooltip="render layer to SVG">
+                                <span class="material-icons" alt="export render">camera_alt</span>
+                            </div>
+                        </div>
+                    </div>
+                    <div>
+                        <b class="filter-label">Options</b>
+                    </div>
+                    <!-- Additional Export Options -->
+                    <div>
+                        <input id="select_download_annotations" class="checkbox-custom" type="checkbox" [(ngModel)]="downloadAnnotationsOnVisibleTechniques">
+                        <label for="select_download_annotations" class="checkbox-custom-label noselect">Only download annotations on visible techniques</label>
+                    </div>
+                    <div class="warning" *ngIf="downloadAnnotationsOnVisibleTechniques && this.viewModel.modifiedHiddenTechniques() == 1">
+                        <span class="material-icons" alt="warning">warning</span>
+                        <label class="warning-label"> {{this.viewModel.modifiedHiddenTechniques()}} hidden technique has annotations</label>
+                    </div>
+                    <div class="warning" *ngIf="downloadAnnotationsOnVisibleTechniques && this.viewModel.modifiedHiddenTechniques() > 1">
+                        <span class="material-icons" alt="warning">warning</span>
+                        <label class="warning-label"> {{this.viewModel.modifiedHiddenTechniques()}} hidden techniques have annotations</label>
+                    </div>
                 </div>
             </div>
 

--- a/nav-app/src/app/datatable/data-table.component.scss
+++ b/nav-app/src/app/datatable/data-table.component.scss
@@ -325,7 +325,7 @@ $cellSize: 15px;
 }
 
 .warning {
-  color: orange;
+  @include adaptive-color("color", #b30000, #ffab0f);
 }
 
 .warning-label {

--- a/nav-app/src/app/datatable/data-table.component.scss
+++ b/nav-app/src/app/datatable/data-table.component.scss
@@ -325,7 +325,7 @@ $cellSize: 15px;
 }
 
 .warning {
-  color: yellow;
+  color: orange;
 }
 
 .warning-label {

--- a/nav-app/src/app/datatable/data-table.component.scss
+++ b/nav-app/src/app/datatable/data-table.component.scss
@@ -324,6 +324,14 @@ $cellSize: 15px;
   }
 }
 
+.warning {
+  color: yellow;
+}
+
+.warning-label {
+  vertical-align: super;
+}
+
 .multiselect {
   // padding: 4px;
   text-align: center;

--- a/nav-app/src/app/datatable/data-table.component.ts
+++ b/nav-app/src/app/datatable/data-table.component.ts
@@ -54,6 +54,8 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
         this.scrollRef.nativeElement.style.height = `calc(100vh - ${scrollWindowHeight}px)`;
     }
 
+    public downloadAnnotationsOnVisibleTechniques: boolean = false;
+
     // edit field bindings
     public commentEditField: string = "";
     public scoreEditField: string = "";
@@ -107,7 +109,7 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
      * JSON file
      */
     public saveLayerLocally(): void {
-        let json = this.viewModel.serialize();
+        let json = this.viewModel.serialize(this.downloadAnnotationsOnVisibleTechniques);
         let blob = new Blob([json], {type: "text/json"});
         let filename = this.viewModel.name.toLowerCase().replace(/ /g, "_") + ".json";
         this.saveBlob(blob, filename);
@@ -291,6 +293,18 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
         }
         this.dropdownChange.emit(this.currentDropdown);
     }
+
+        /**
+     * Handle export drop down change
+     */
+        public handleExportDropdown(): void {
+            if (this.currentDropdown !== 'export') {
+                this.currentDropdown = 'export';
+            } else {
+                this.currentDropdown = '';
+            }
+            this.dropdownChange.emit(this.currentDropdown);
+        }
 
     /**
      * Triggered on left click of technique

--- a/nav-app/src/app/services/viewmodels.service.ts
+++ b/nav-app/src/app/services/viewmodels.service.ts
@@ -1093,22 +1093,24 @@ export class ViewModel {
     // |___/___|_|_\___/_/ \_\____|___/___/_/ \_\_| |___\___/|_|\_|
 
     /**
-     * List of technique and subtechnique attack IDs
+     * List of visible technique and subtechnique attack IDs
      *
-     * @returns list of strings of each technique and subtechnique attack ID
+     * @returns list of strings of each visible technique and subtechnique attack ID
      */
-    getTechniquesList(): string[] {
+    getVisibleTechniquesList(): string[] {
         let techniqueList = []
         let d = this.dataService.getDomain(this.domainVersionID);
         for (let matrix of d.matrices) {
             for (let tactic of this.filterTactics(matrix.tactics, matrix)) {
                 let techniques = this.applyControls(tactic.techniques, tactic, matrix);
                 for (let technique of techniques) {
-                    techniqueList.push(technique.attackID)
+                    let technique_tactic_union_id = technique.get_technique_tactic_id(tactic);
+                    techniqueList.push(technique_tactic_union_id);
                     let subtechniques = this.applyControls(technique.subtechniques, tactic, matrix)
                     .map( sub => { return sub });
                     for (let subtechnique of subtechniques) {
-                        techniqueList.push(subtechnique.attackID)
+                        let subtechnique_tactic_union_id = subtechnique.get_technique_tactic_id(tactic);
+                        techniqueList.push(subtechnique_tactic_union_id);
                     }
                 }
             }
@@ -1122,10 +1124,10 @@ export class ViewModel {
      */
     modifiedHiddenTechniques(): number {
         let modifiedHiddenTechniques = 0
-        let techniqueList = this.getTechniquesList()
+        let techniqueList = this.getVisibleTechniquesList()
         this.techniqueVMs.forEach(function(value,key) {
             if (value.modified()) {
-                if (!techniqueList.includes(value.techniqueID)) {
+                if (!techniqueList.includes(value.technique_tactic_union_id)) {
                     modifiedHiddenTechniques++
                 }
             }
@@ -1138,7 +1140,7 @@ export class ViewModel {
      * @return string representation
      */
     serialize(downloadAnnotationsOnVisibleTechniques: boolean): string {
-        let techniqueList = this.getTechniquesList()
+        let techniqueList = this.getVisibleTechniquesList()
 
         let modifiedTechniqueVMs = [];
         this.techniqueVMs.forEach(function(value,key) {
@@ -1146,7 +1148,7 @@ export class ViewModel {
                 modifiedTechniqueVMs.push(JSON.parse(value.serialize())) //only save techniqueVMs which have been modified
             }
             else if (value.modified() && downloadAnnotationsOnVisibleTechniques) {
-                if (techniqueList.includes(value.techniqueID)) {
+                if (techniqueList.includes(value.technique_tactic_union_id)) {
                     modifiedTechniqueVMs.push(JSON.parse(value.serialize())) //only save techniqueVMs which have been modified and are visible
                 }
             }

--- a/nav-app/src/app/services/viewmodels.service.ts
+++ b/nav-app/src/app/services/viewmodels.service.ts
@@ -1093,11 +1093,11 @@ export class ViewModel {
     // |___/___|_|_\___/_/ \_\____|___/___/_/ \_\_| |___\___/|_|\_|
 
     /**
-     * Number of modified hidden techniques
-     * @returns number of hidden techniques that are annotated
+     * List of technique and subtechnique attack IDs
+     *
+     * @returns list of strings of each technique and subtechnique attack ID
      */
-    modifiedHiddenTechniques(): number {
-        let modifiedHiddenTechniques = 0
+    getTechniquesList(): string[] {
         let techniqueList = []
         let d = this.dataService.getDomain(this.domainVersionID);
         for (let matrix of d.matrices) {
@@ -1113,6 +1113,16 @@ export class ViewModel {
                 }
             }
         }
+        return techniqueList
+    }
+
+    /**
+     * Number of modified hidden techniques
+     * @returns number of hidden techniques that are annotated
+     */
+    modifiedHiddenTechniques(): number {
+        let modifiedHiddenTechniques = 0
+        let techniqueList = this.getTechniquesList()
         this.techniqueVMs.forEach(function(value,key) {
             if (value.modified()) {
                 if (!techniqueList.includes(value.techniqueID)) {
@@ -1128,21 +1138,8 @@ export class ViewModel {
      * @return string representation
      */
     serialize(downloadAnnotationsOnVisibleTechniques: boolean): string {
-        let techniqueList = []
-        let d = this.dataService.getDomain(this.domainVersionID);
-        for (let matrix of d.matrices) {
-            for (let tactic of this.filterTactics(matrix.tactics, matrix)) {
-                let techniques = this.applyControls(tactic.techniques, tactic, matrix);
-                for (let technique of techniques) {
-                    techniqueList.push(technique.attackID)
-                    let subtechniques = this.applyControls(technique.subtechniques, tactic, matrix)
-                    .map( sub => { return sub });
-                    for (let subtechnique of subtechniques) {
-                        techniqueList.push(subtechnique.attackID)
-                    }
-                }
-            }
-        }
+        let techniqueList = this.getTechniquesList()
+
         let modifiedTechniqueVMs = [];
         this.techniqueVMs.forEach(function(value,key) {
             if (value.modified() && !downloadAnnotationsOnVisibleTechniques) {


### PR DESCRIPTION
Includes the following changes to the toolbar's export features:

- Consolidates all three export options into a single dropdown
- Includes option to only download annotations on visible techniques
- Displays warning text if there are hidden techniques that are annotated 

Resolves https://github.com/mitre-attack/attack-navigator/issues/215