### PR TITLE
Dark Theme for SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Adds support for ATT&CK v13.
 ## Improvements
 - Users can disable the background color effect on manually assigned colors, aggregate scores, or non-aggregate scores by editing `src/assets/config.json` or through the "Create Customized Navigator" interface. See issue [#371](https://github.com/mitre-attack/attack-navigator/issues/371).
 - Added image orientation options and new preset image size options to the SVG exporter. See issue [#547](https://github.com/mitre-attack/attack-navigator/pull/547).
+- Added ability to render SVG export in dark mode. See issue [#564](https://github.com/mitre-attack/attack-navigator/pull/564)
 
 ## Fixes
 - Fixed an issue where aggregate scores were calculated on techniques with no sub-techniques. See issue [#539](https://github.com/mitre-attack/attack-navigator/issues/539).

--- a/nav-app/src/app/svg-export/renderable-objects/renderable-technique.ts
+++ b/nav-app/src/app/svg-export/renderable-objects/renderable-technique.ts
@@ -27,7 +27,7 @@ export class RenderableTechnique {
             if (this.viewModel.layout.showAggregateScores && techniqueVM.aggregateScoreColor) return techniqueVM.aggregateScoreColor;
             if (techniqueVM.score) return techniqueVM.scoreColor;
         }
-        return "white"; //default
+        return null; //default
     }
 
     public get textColor() {
@@ -35,7 +35,10 @@ export class RenderableTechnique {
             let techniqueVM: TechniqueVM = this.viewModel.getTechniqueVM(this.technique, this.tactic);
             if (!techniqueVM.enabled) return "#aaaaaa";
         }
-        return tinycolor.mostReadable(this.fill, ["white", "black"]); //default;
+        if (this.fill) {
+            return tinycolor.mostReadable(this.fill, ["white", "black"]); //default;
+        }
+        return null;
     }
 
     public get text() {

--- a/nav-app/src/app/svg-export/svg-export.component.html
+++ b/nav-app/src/app/svg-export/svg-export.component.html
@@ -5,6 +5,18 @@
         </li>
         <li>
             <div class="control-row-item noselect">
+                <!-- {{config.theme}} -->
+                <div class="control-row-button"
+                     (click)="themeEnum = (themeEnum + 1) % 2; config.theme = ['light', 'dark'][themeEnum]; buildSVG()"
+                     matTooltipPosition="below"
+                     matTooltip="theme">
+                     <span *ngIf="config.theme === 'light'" class="material-icons">nightlight_round</span>
+                     <span *ngIf="config.theme === 'dark'" class="material-icons">wb_sunny</span>
+                </div>
+            </div>
+        </li>
+        <li>
+            <div class="control-row-item noselect">
                 <!-- {{config.unit}} -->
                 <div class="control-row-button"
                      (click)="unitEnum = (unitEnum + 1) % 3; config.unit = ['in', 'cm', 'px'][unitEnum]; buildSVG()"
@@ -249,7 +261,7 @@
     </ul>
 </div>
 
-<div class="svgcontainer" [id]="'svgInsert' + viewModel.uid">
+<div [ngClass]="[config.theme === 'light' ? 'svgcontainer' : 'svgcontainer dark-mode']" [id]="'svgInsert' + viewModel.uid">
     loading...
 </div>
 

--- a/nav-app/src/app/svg-export/svg-export.component.scss
+++ b/nav-app/src/app/svg-export/svg-export.component.scss
@@ -8,6 +8,10 @@
     min-width: 75vw;
     max-width: 75vw;
     padding:25px;
+
+    &.dark-mode {
+        background-color: color(dark-1) !important;
+    }
 }
 
 .close-button {

--- a/nav-app/src/app/svg-export/svg-export.component.ts
+++ b/nav-app/src/app/svg-export/svg-export.component.ts
@@ -30,6 +30,7 @@ export class SvgExportComponent implements OnInit {
         "unit": "in",
         "orientation": "landscape",
         "size": "letter",
+        "theme": "light",
         "showSubtechniques": "expanded",
         "font": "sans-serif",
         "tableBorderColor": "#6B7279",
@@ -55,6 +56,9 @@ export class SvgExportComponent implements OnInit {
 
     // counter for unit change ui element
     public unitEnum: number = 0;
+
+    // counter for theme change ui element
+    public themeEnum: number = 0;
     
     // browser compatibility
     public get isIE(): boolean { return is.ie(); }
@@ -108,6 +112,14 @@ export class SvgExportComponent implements OnInit {
         this.config.legendX = this.config.width - this.config.legendWidth - 0.1;
         this.config.legendY = this.config.height - this.config.legendHeight - 0.1;
         if (this.config.showHeader) this.config.legendY -= this.config.headerHeight; 
+
+        //initial table border color
+        if (this.config.theme === 'light') {
+            this.config.tableBorderColor = "#6B7279"
+        }
+        else if (this.config.theme === 'dark') {
+            this.config.tableBorderColor = "#4c4c68"
+        }
 
         // build SVG at end of fn queue so page can render before build
         window.setTimeout(function() {
@@ -310,7 +322,7 @@ export class SvgExportComponent implements OnInit {
             .attr("class", "cell")
             .attr("height", yRange(1))
             .attr("width", xRange.bandwidth())
-            .attr("fill", function(technique: RenderableTechnique) { return technique.fill })
+            .attr("fill", function(technique: RenderableTechnique) { return technique.fill !== null ? technique.fill : self.config.theme === "light" ? "#ffffff" : "#2e2e3f" })
             .attr("stroke", self.config.tableBorderColor);
 
         // add cell style to sub-techniques
@@ -318,7 +330,7 @@ export class SvgExportComponent implements OnInit {
             .attr("class", "cell")
             .attr("height", yRange(1))
             .attr("width", xRange.bandwidth() - subtechniqueIndent)
-            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.fill })
+            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.fill !== null ? subtechnique.fill : self.config.theme === "light" ? "#ffffff" : "#2e2e3f" })
             .attr("stroke", self.config.tableBorderColor);
 
         // add styling for sub-technique sidebar
@@ -358,7 +370,7 @@ export class SvgExportComponent implements OnInit {
                 if (fontSize < minFontSize) minFontSize = fontSize;
                 return fontSize;
             })
-            .attr("fill", function(technique: RenderableTechnique) { return technique.textColor; })
+            .attr("fill", function(technique: RenderableTechnique) { return technique.textColor !== null ? technique.textColor : self.config.theme === "light" ? "#000000" : "#ffffff" })
             .each(function() { self.verticalAlignCenter(this); })
 
         // set sub-technique font size
@@ -369,7 +381,7 @@ export class SvgExportComponent implements OnInit {
                 if (fontSize < minFontSize) minFontSize = fontSize;
                 return fontSize;
             })
-            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.textColor; })
+            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.textColor !== null ? subtechnique.textColor : self.config.theme === "light" ? "#000000" : "#ffffff" })
             .each(function() { self.verticalAlignCenter(this); })
     
         // set technique and sub-technique groups to the same font size
@@ -390,7 +402,7 @@ export class SvgExportComponent implements OnInit {
             })
             .attr("fill", function(tactic: RenderableTactic) {
                 if (self.viewModel.showTacticRowBackground) return tinycolor.mostReadable(self.viewModel.tacticRowBackground, ["white", "black"]); 
-                else return "black";
+                else return self.config.theme === 'light' ? "black" : "white";
             })
             .attr("font-weight", "bold")
             .each(function() { self.verticalAlignCenter(this); })
@@ -434,8 +446,8 @@ export class SvgExportComponent implements OnInit {
             .attr("class", "header-box")
             .attr("width", width)
             .attr("height", height)
-            .attr("stroke", "black")
-            .attr("fill", "white")
+            .attr("stroke", self.config.theme === 'light' ? "black" : "#4c4c68")
+            .attr("fill", self.config.theme === 'light' ? "white" : "#1a1a23")
             .attr("rx", padding); // rounded corner
 
         // box title
@@ -444,6 +456,7 @@ export class SvgExportComponent implements OnInit {
             .text(section.title)
             .attr("x", 2 * padding)
             .attr("font-size", 12)
+            .attr("fill", self.config.theme === 'light' ? "black" : "white")
             .each(function() { self.verticalAlignCenter(this); })
 
         // add cover mask so that the box lines crop around the text
@@ -455,13 +468,14 @@ export class SvgExportComponent implements OnInit {
             .attr("y", bbox.y - coverPadding)
             .attr("width", bbox.width + 2 * coverPadding)
             .attr("height", bbox.height + 2 * coverPadding)
-            .attr("fill", "white")
+            .attr("fill", self.config.theme === 'light' ? "white" : "#1a1a23")
             .attr("rx", padding); // rounded corner
         boxTitle.raise(); // push title to front
 
         // add content to box
         let boxContentGroup = boxGroup.append("g")
             .attr("class", "header-box-content")
+            .attr("fill", self.config.theme === 'light' ? "black" : "white")
             .attr("transform", `translate(${padding}, 0)`)
 
         let yRange = d3.scaleBand()

--- a/nav-app/src/app/svg-export/svg-export.component.ts
+++ b/nav-app/src/app/svg-export/svg-export.component.ts
@@ -322,7 +322,18 @@ export class SvgExportComponent implements OnInit {
             .attr("class", "cell")
             .attr("height", yRange(1))
             .attr("width", xRange.bandwidth())
-            .attr("fill", function(technique: RenderableTechnique) { return technique.fill !== null ? technique.fill : self.config.theme === "light" ? "#ffffff" : "#2e2e3f" })
+            .attr("fill", function(technique: RenderableTechnique) {
+                if (technique.fill !== null) {
+                    return technique.fill;
+                }
+                else {
+                    if (self.config.theme === "light") {
+                        return "#ffffff";
+                    }
+                    else {
+                        return "#2e2e3f";
+                    }
+                }})
             .attr("stroke", self.config.tableBorderColor);
 
         // add cell style to sub-techniques
@@ -330,7 +341,18 @@ export class SvgExportComponent implements OnInit {
             .attr("class", "cell")
             .attr("height", yRange(1))
             .attr("width", xRange.bandwidth() - subtechniqueIndent)
-            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.fill !== null ? subtechnique.fill : self.config.theme === "light" ? "#ffffff" : "#2e2e3f" })
+            .attr("fill", function(subtechnique: RenderableTechnique) {
+                if (subtechnique.fill !== null) {
+                    return subtechnique.fill;
+                }
+                else {
+                    if (self.config.theme === "light") {
+                        return "#ffffff";
+                    }
+                    else {
+                        return "#2e2e3f";
+                    }
+                }})
             .attr("stroke", self.config.tableBorderColor);
 
         // add styling for sub-technique sidebar
@@ -370,7 +392,18 @@ export class SvgExportComponent implements OnInit {
                 if (fontSize < minFontSize) minFontSize = fontSize;
                 return fontSize;
             })
-            .attr("fill", function(technique: RenderableTechnique) { return technique.textColor !== null ? technique.textColor : self.config.theme === "light" ? "#000000" : "#ffffff" })
+            .attr("fill", function(technique: RenderableTechnique) {
+                if (technique.textColor !== null) {
+                    return technique.textColor;
+                }
+                else {
+                    if (self.config.theme === "light") {
+                        return "#000000";
+                    }
+                    else {
+                        return "#ffffff";
+                    }
+                }})
             .each(function() { self.verticalAlignCenter(this); })
 
         // set sub-technique font size
@@ -381,7 +414,18 @@ export class SvgExportComponent implements OnInit {
                 if (fontSize < minFontSize) minFontSize = fontSize;
                 return fontSize;
             })
-            .attr("fill", function(subtechnique: RenderableTechnique) { return subtechnique.textColor !== null ? subtechnique.textColor : self.config.theme === "light" ? "#000000" : "#ffffff" })
+            .attr("fill", function(subtechnique: RenderableTechnique) {
+                if (subtechnique.textColor !== null) {
+                    return subtechnique.textColor;
+                }
+                else {
+                    if (self.config.theme === "light") {
+                        return "#000000";
+                    }
+                    else {
+                        return "#ffffff";
+                    }
+                }})
             .each(function() { self.verticalAlignCenter(this); })
     
         // set technique and sub-technique groups to the same font size


### PR DESCRIPTION
Added ability to render SVG export in dark theme. Changes include: 

- Toggle button on SVG exporter toolbar to switch between dark and light theme

Resolves https://github.com/mitre-attack/attack-navigator/issues/556