### PR TITLE
Metadata underline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 ## Improvements
 - Added ability to render SVG export in dark mode. See issue [#564](https://github.com/mitre-attack/attack-navigator/pull/564).
 - Updated Angular from 11.0.3 to 14.3.0.
+- Added the ability to be able to select whether or not to display the metadata underline either by changing the config file or by using the customized navigator. See issue [#400](https://github.com/mitre-attack/attack-navigator/issues/400)
 
 ## Miscellaneous
 

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -130,7 +130,7 @@ export abstract class Cell {
                 if (this.configService.getFeature('comment_underline')) return this.configService.comment_color;
             }
             if (tvm.metadata.length > 0) {
-                if (this.configService.getFeature('metadata_underline')) return this.configService.comment_color;
+                if (this.configService.getFeature('metadata_underline')) return this.configService.metadata_color;
             }
             if (tvm.links.length > 0) {
                 if (this.configService.getFeature('link_underline')) return this.configService.link_color;

--- a/nav-app/src/app/matrix/cell.ts
+++ b/nav-app/src/app/matrix/cell.ts
@@ -126,8 +126,11 @@ export abstract class Cell {
     public getTechniqueUnderlineColor() {
         if (this.tactic) {
             let tvm = this.viewModel.getTechniqueVM(this.technique, this.tactic);
-            if (tvm.comment.length > 0 || tvm.metadata.length > 0 || this.hasNotes()) {
+            if (tvm.comment.length > 0 || this.hasNotes()) {
                 if (this.configService.getFeature('comment_underline')) return this.configService.comment_color;
+            }
+            if (tvm.metadata.length > 0) {
+                if (this.configService.getFeature('metadata_underline')) return this.configService.comment_color;
             }
             if (tvm.links.length > 0) {
                 if (this.configService.getFeature('link_underline')) return this.configService.link_color;

--- a/nav-app/src/app/services/config.service.ts
+++ b/nav-app/src/app/services/config.service.ts
@@ -8,6 +8,7 @@ import { ContextMenuItem } from '../classes/context-menu-item';
 export class ConfigService {
     public comment_color = "yellow";
     public link_color = "blue";
+    public metadata_color = "purple";
     public banner: string;
     private features = new Map<string, boolean>();
     private featureGroups = new Map<string, string[]>();
@@ -34,6 +35,7 @@ export class ConfigService {
                 dataService.subtechniquesEnabled = self.getFeature("subtechniques");
                 self.featureStructure = config["features"];
                 self.comment_color = config["comment_color"];
+                self.metadata_color = config["metadata_color"];
                 self.link_color = config["link_color"];
                 self.banner = config["banner"];
                 for (let obj of config["custom_context_menu_items"]) {

--- a/nav-app/src/assets/config.json
+++ b/nav-app/src/assets/config.json
@@ -238,6 +238,7 @@
             {"name": "scoring", "enabled": true, "description": "Disable to remove the ability to score techniques."},
             {"name": "comments", "enabled": true, "description": "Disable to remove the ability to add comments to techniques."},
             {"name": "comment_underline", "enabled": true, "description": "Disable to remove the comment underline effect on techniques."},
+            {"name": "metadata_underline", "enabled": false, "description": "Disable to remove the metadata underline effect on techniques."},
             {"name": "links", "enabled": true, "description": "Disable to remove the ability to assign hyperlinks to techniques."},
             {"name": "link_underline", "enabled": true, "description": "Disable to remove the hyperlink underline effect on techniques."},
             {"name": "metadata", "enabled": true, "description": "Disable to remove the ability to add metadata to techniques."},

--- a/nav-app/src/assets/config.json
+++ b/nav-app/src/assets/config.json
@@ -203,6 +203,7 @@
 
     "comment_color": "yellow",
     "link_color": "blue",
+    "metadata_color": "purple",
 
     "banner": "",
 
@@ -238,7 +239,7 @@
             {"name": "scoring", "enabled": true, "description": "Disable to remove the ability to score techniques."},
             {"name": "comments", "enabled": true, "description": "Disable to remove the ability to add comments to techniques."},
             {"name": "comment_underline", "enabled": true, "description": "Disable to remove the comment underline effect on techniques."},
-            {"name": "metadata_underline", "enabled": false, "description": "Disable to remove the metadata underline effect on techniques."},
+            {"name": "metadata_underline", "enabled": true, "description": "Disable to remove the metadata underline effect on techniques."},
             {"name": "links", "enabled": true, "description": "Disable to remove the ability to assign hyperlinks to techniques."},
             {"name": "link_underline", "enabled": true, "description": "Disable to remove the hyperlink underline effect on techniques."},
             {"name": "metadata", "enabled": true, "description": "Disable to remove the ability to add metadata to techniques."},


### PR DESCRIPTION
This pull request addresses part of #400. The user should now be able to select whether or not to display the metadata underline either by changing the config file or by using the customized navigator.