### PR TITLE
Expand annotated subtechniques

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@
 
 ## Layer File Format Changes
 
-Layer file format updated to version 4.5. This update adds support for selecting only visible techniques. The `selectVisibleTechniques` field specifies whether or not hidden techniques will be included in the different select behaviors. See [layers/LAYERFORMATv4_5.md](layers/LAYERFORMATv4_5.md) for the full specification.
+Layer file format updated to version 4.5. This update adds support for selecting only visible techniques. The `selectVisibleTechniques` field specifies whether or not hidden techniques will be included in the different select behaviors.
+This update also adds support for configuring how to display sub-techniques in the layer file with the help of the `expandedSubtechniques` field. This property can be set to `all`, `none`, or `annotated` to display the sub-techniques. See [layers/LAYERFORMATv4_5.md](layers/LAYERFORMATv4_5.md) for the full specification.
 
 # 4.8.2 - 9 May 2023
 
@@ -52,6 +53,7 @@ Adds support for ATT&CK v13.
 
 ## New Features
 - Added the ability to create a layer from a custom [Collection](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/blob/develop/docs/collections.md#collections) or Stix Bundle. Users can specify the URL, version, and domain of a custom bundle in the Create New Layer interface. This will load the base data from the file at the given URL into the Navigator. Layers created from a custom collection/STIX bundle support all of the standard layer features (annotations, filter/sort, download/upload, layer-layer operations, etc.), apart from upgrading the layer to a newer ATT&CK version. See issue [#499](https://github.com/mitre-attack/attack-navigator/issues/499).
+- Users should now be able to configure how to display sub-techniques in the layer file through the `expandedSubtechniques` property - annotated, all, or none. See issue [#560](https://github.com/mitre-attack/attack-navigator/issues/560)
 
 ## Layer File Format Changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 ## New Features
 - Consolidated the JSON, Excel, and SVG export options into a single dropdown. Added an option to the export interface to only download annotations on visible techniques. See issue [#215](https://github.com/mitre-attack/attack-navigator/issues/215).
 - Extended search interface to support searching for techniques by asset.
+- Users should now be able to configure how to display sub-techniques in the layer file through the `expandedSubtechniques` property - annotated, all, or none. See issue [#560](https://github.com/mitre-attack/attack-navigator/issues/560) and the `Layer File Format Changes` section.
 
 ## Improvements
 - Added ability to render SVG export in dark mode. See issue [#564](https://github.com/mitre-attack/attack-navigator/pull/564).
@@ -54,7 +55,6 @@ Adds support for ATT&CK v13.
 
 ## New Features
 - Added the ability to create a layer from a custom [Collection](https://github.com/center-for-threat-informed-defense/attack-workbench-frontend/blob/develop/docs/collections.md#collections) or Stix Bundle. Users can specify the URL, version, and domain of a custom bundle in the Create New Layer interface. This will load the base data from the file at the given URL into the Navigator. Layers created from a custom collection/STIX bundle support all of the standard layer features (annotations, filter/sort, download/upload, layer-layer operations, etc.), apart from upgrading the layer to a newer ATT&CK version. See issue [#499](https://github.com/mitre-attack/attack-navigator/issues/499).
-- Users should now be able to configure how to display sub-techniques in the layer file through the `expandedSubtechniques` property - annotated, all, or none. See issue [#560](https://github.com/mitre-attack/attack-navigator/issues/560)
 
 ## Layer File Format Changes
 

--- a/layers/LAYERFORMATv4_5.md
+++ b/layers/LAYERFORMATv4_5.md
@@ -100,6 +100,7 @@ Note: Divider objects can be used alongside Link objects.
 | showAggregateScores | Boolean | No | false | if true, show the aggregate scores of techniques and its subtechniques in the matrix |
 | countUnscored | Boolean | No | false | if true, count the unscored techniques in the calculation of the aggregate score of techniques in the matrix |
 | aggregateFunction | String | No | "average" | The aggregate function used to calculate aggregate scores for techniques in the matrix. Either "average", "min", "max" or "sum" |
+| expandedSubtechniques | String | No | "none' | How to display the subtechniques. Either "none", "all" or "annotated" |
 
 ## Example
 The following example illustrates the layer file format:
@@ -126,7 +127,8 @@ The following example illustrates the layer file format:
         "showID": false,
         "showAggregateScores": true,
         "countUnscored": true,
-        "aggregateFunction": "average"
+        "aggregateFunction": "average",
+        "expandedSubtechniques": "annotated"
     },
     "hideDisabled": false,
     "techniques": [

--- a/layers/LAYERFORMATv4_5.md
+++ b/layers/LAYERFORMATv4_5.md
@@ -100,7 +100,7 @@ Note: Divider objects can be used alongside Link objects.
 | showAggregateScores | Boolean | No | false | if true, show the aggregate scores of techniques and its subtechniques in the matrix |
 | countUnscored | Boolean | No | false | if true, count the unscored techniques in the calculation of the aggregate score of techniques in the matrix |
 | aggregateFunction | String | No | "average" | The aggregate function used to calculate aggregate scores for techniques in the matrix. Either "average", "min", "max" or "sum" |
-| expandedSubtechniques | String | No | "none' | How to display the subtechniques. Either "none", "all" or "annotated" |
+| expandedSubtechniques | String | No | "none" | How to display the subtechniques. Either "none", "all" or "annotated" |
 
 ## Example
 The following example illustrates the layer file format:

--- a/nav-app/src/app/classes/layout-options.ts
+++ b/nav-app/src/app/classes/layout-options.ts
@@ -56,6 +56,18 @@ export class LayoutOptions {
 	public set countUnscored(newval: boolean) { this._countUnscored = newval; }
 	public get countUnscored(): boolean { return (this.aggregateFunction === "average") ? this._countUnscored : false; }
 
+	// how to display subtechniques
+	public expandedSubtechniquesOptions: string[] = ["none", "annotated", "all"];
+	private _expandedSubtechniques = this.expandedSubtechniquesOptions[0];
+	public set expandedSubtechniques(newExpandedSubtechniques) {
+		if (!this.expandedSubtechniquesOptions.includes(newExpandedSubtechniques)) {
+			console.warn("invalid expand subtechnique option", newExpandedSubtechniques);
+			return;
+		}
+		this._expandedSubtechniques = newExpandedSubtechniques;
+	}
+	public get expandedSubtechniques(): string { return this._expandedSubtechniques; }
+
 	public serialize(): object {
 		return {
 			"layout": this.layout,
@@ -63,7 +75,8 @@ export class LayoutOptions {
 			"showID": this.showID,
 			"showName": this.showName,
 			"showAggregateScores": this.showAggregateScores,
-			"countUnscored": this.countUnscored
+			"countUnscored": this.countUnscored,
+			"expandedSubtechniques": this.expandedSubtechniques
 		};
 	}
 
@@ -92,6 +105,10 @@ export class LayoutOptions {
 		if ("countUnscored" in rep) {
 			if (typeof (rep.countUnscored) === "boolean") this.countUnscored = rep.countUnscored;
 			else console.error("TypeError: layout field 'countUnscored' is not a boolean:", rep.countUnscored, "(", typeof (rep.countUnscored), ")");
+		}
+		if ("expandedSubtechniques" in rep) {
+			if (typeof (rep.expandedSubtechniques) === "string") this.expandedSubtechniques = rep.expandedSubtechniques;
+			else console.error("TypeError: layout field 'expandedSubtechniques' is not a string:", rep.expandedSubtechniques, "(", typeof (rep.expandedSubtechniques), ")");
 		}
 	}
 }

--- a/nav-app/src/app/classes/view-model.ts
+++ b/nav-app/src/app/classes/view-model.ts
@@ -47,7 +47,7 @@ export class ViewModel {
 
     public metadata: Metadata[] = [];
     public links: Link[] = [];
-    public technique_has_subtechnique = false;
+    public technique_show_subtechnique = false;
 
     /*
      * 0: ascending alphabetically
@@ -156,13 +156,13 @@ export class ViewModel {
                     for (let id of technique.get_all_technique_tactic_ids()) {
                         let tvm = this.getTechniqueVM_id(id);
                             if(tvm.showSubtechniques){
-                                this.technique_has_subtechnique = true;
+                                this.technique_show_subtechnique = true;
                                 break;
                             }
                     }
                 }
             }
-            if(this.layout.expandedSubtechniques=="none" && this.technique_has_subtechnique==false){
+            if(this.layout.expandedSubtechniques=="none" && !this.technique_show_subtechnique){
                 this.techniqueVMs.forEach(function(tvm) {
                     tvm.showSubtechniques = false;
                 });

--- a/nav-app/src/app/classes/view-model.ts
+++ b/nav-app/src/app/classes/view-model.ts
@@ -122,6 +122,40 @@ export class ViewModel {
                 }
             }
         }
+        // display annotated subtechniques if "annotated" option is selected
+        if(this.layout.expandedSubtechniques=="annotated"){
+            for (let technique of this.dataService.getDomain(this.domainVersionID).techniques) {
+                if (technique.subtechniques.length > 0) {
+                    for (let id of technique.get_all_technique_tactic_ids()) {
+                        let tvm = this.getTechniqueVM_id(id);
+                        for (let subtechnique of technique.subtechniques) {
+                            tvm.showSubtechniques = tvm.showSubtechniques || subtechnique.get_all_technique_tactic_ids().some((sid) => {
+                                let svm = this.getTechniqueVM_id(sid);
+                                return svm.annotated();
+                            })
+                        }
+                    }
+                }
+            }
+        }
+        // display all subtechniques if "all" option is selected
+        else if(this.layout.expandedSubtechniques=="all"){
+            for (let technique of this.dataService.getDomain(this.domainVersionID).techniques) {
+                if (technique.subtechniques.length > 0) {
+                    for (let id of technique.get_all_technique_tactic_ids()) {
+                        let tvm = this.getTechniqueVM_id(id);
+                            tvm.showSubtechniques = true;
+                    }
+                }
+            }
+        }
+        // display none of the subtechniques if "none" option is selected
+        else if(this.layout.expandedSubtechniques=="none"){
+            this.techniqueVMs.forEach(function(tvm) {
+                tvm.showSubtechniques = false;
+            });
+        }
+
     }
 
     public getTechniqueVM(technique: Technique, tactic: Tactic): TechniqueVM {

--- a/nav-app/src/app/classes/view-model.ts
+++ b/nav-app/src/app/classes/view-model.ts
@@ -47,6 +47,7 @@ export class ViewModel {
 
     public metadata: Metadata[] = [];
     public links: Link[] = [];
+    public technique_has_subtechnique = false;
 
     /*
      * 0: ascending alphabetically
@@ -149,13 +150,25 @@ export class ViewModel {
                 }
             }
         }
-        // display none of the subtechniques if "none" option is selected
-        else if(this.layout.expandedSubtechniques=="none"){
-            this.techniqueVMs.forEach(function(tvm) {
-                tvm.showSubtechniques = false;
-            });
+        else{
+            for (let technique of this.dataService.getDomain(this.domainVersionID).techniques) {
+                if (technique.subtechniques.length > 0) {
+                    for (let id of technique.get_all_technique_tactic_ids()) {
+                        let tvm = this.getTechniqueVM_id(id);
+                            if(tvm.showSubtechniques){
+                                this.technique_has_subtechnique = true;
+                                break;
+                            }
+                    }
+                }
+            }
+            if(this.layout.expandedSubtechniques=="none" && this.technique_has_subtechnique==false){
+                this.techniqueVMs.forEach(function(tvm) {
+                    tvm.showSubtechniques = false;
+                });
+            }
         }
-
+        // display none of the subtechniques if "none" option is selected
     }
 
     public getTechniqueVM(technique: Technique, tactic: Tactic): TechniqueVM {

--- a/nav-app/src/app/datatable/data-table.component.ts
+++ b/nav-app/src/app/datatable/data-table.component.ts
@@ -332,7 +332,7 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
      */
     public expandSubtechniques(showAnnotatedOnly?: boolean): void {
         if (this.viewModel.layout.layout == "mini") return; // control disabled in mini layout
-        if (showAnnotatedOnly == true){
+        if (showAnnotatedOnly){
             this.viewModel.layout.expandedSubtechniques = "annotated";
         }
         else{

--- a/nav-app/src/app/datatable/data-table.component.ts
+++ b/nav-app/src/app/datatable/data-table.component.ts
@@ -332,6 +332,12 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
      */
     public expandSubtechniques(showAnnotatedOnly?: boolean): void {
         if (this.viewModel.layout.layout == "mini") return; // control disabled in mini layout
+        if (showAnnotatedOnly == true){
+            this.viewModel.layout.expandedSubtechniques = "annotated";
+        }
+        else{
+            this.viewModel.layout.expandedSubtechniques = "all";
+        }
         for (let technique of this.dataService.getDomain(this.viewModel.domainVersionID).techniques) {
             if (technique.subtechniques.length > 0) {
                 for (let id of technique.get_all_technique_tactic_ids()) {
@@ -359,6 +365,7 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
         this.viewModel.techniqueVMs.forEach(function(tvm, key) {
             tvm.showSubtechniques = false;
         });
+        this.viewModel.layout.expandedSubtechniques = "none";
     }
 
     /**


### PR DESCRIPTION
This pull request address #560 

Users should now be able to configure how to display sub techniques in the layer file - annotated, all, or none

Includes the metadata_underline change 