### PR TITLE
fixed docker file permission issue at installing packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ WORKDIR /src/nav-app
 # give user permissions
 RUN chown -R node:node ./
 
+USER node
+
 # install packages and build 
 RUN npm install --unsafe-perm --legacy-peer-deps
 
@@ -28,5 +30,3 @@ RUN npm install --unsafe-perm --legacy-peer-deps
 EXPOSE 4200
 
 CMD npm start
-
-USER node


### PR DESCRIPTION
After building the container, you will get an error when starting the service.
Switching to the "node" user before installing the packages fixes the issue.