### PR TITLE
Option to Change SVG Font Size

### DIFF
--- a/nav-app/src/app/svg-export/svg-export.component.html
+++ b/nav-app/src/app/svg-export/svg-export.component.html
@@ -121,7 +121,7 @@
                             </mat-form-field>
                         </li>
                         <li>
-                            <input [id]="uid+'autofit'" type="checkbox" class="checkbox-custom" [(ngModel)]="config.autofitTextSize" (change)="buildSVG()">
+                            <input [id]="uid+'autofit'" type="checkbox" class="checkbox-custom" [(ngModel)]="config.autofitText" (change)="buildSVG()">
                             <label [for]="uid+'autofit'" class="checkbox-custom-label noselect">auto-fit font size</label>
                         </li>
                         <li>
@@ -131,10 +131,14 @@
                                        type="number"
                                        placeholder="font size"
                                        step="1"
-                                       [disabled]="config.autofitTextSize"
+                                       [disabled]="config.autofitText"
                                        [(ngModel)]="config.fontSize"
                                        (input)="buildSVG()" />
                             </mat-form-field>
+                            <div class="warning" *ngIf="!config.autofitText && config.fontSize > config.maxTextSize">
+                                <span class="material-icons" alt="warning" style="padding-right: 5px">warning</span>
+                                <label class="warning-label" style="font-size: 12px">cell text is overflowing</label>
+                            </div>
                         </li>
                     </ul>
                 </div>

--- a/nav-app/src/app/svg-export/svg-export.component.html
+++ b/nav-app/src/app/svg-export/svg-export.component.html
@@ -120,6 +120,22 @@
                                 </mat-select>
                             </mat-form-field>
                         </li>
+                        <li>
+                            <input [id]="uid+'autofit'" type="checkbox" class="checkbox-custom" [(ngModel)]="config.autofitTextSize" (change)="buildSVG()">
+                            <label [for]="uid+'autofit'" class="checkbox-custom-label noselect">auto-fit font size</label>
+                        </li>
+                        <li>
+                            <mat-form-field>
+                                <input matInput
+                                       class="has-suffix"
+                                       type="number"
+                                       placeholder="font size"
+                                       step="1"
+                                       [disabled]="config.autofitTextSize"
+                                       [(ngModel)]="config.fontSize"
+                                       (input)="buildSVG()" />
+                            </mat-form-field>
+                        </li>
                     </ul>
                 </div>
             </div>

--- a/nav-app/src/app/svg-export/svg-export.component.ts
+++ b/nav-app/src/app/svg-export/svg-export.component.ts
@@ -27,6 +27,8 @@ export class SvgExportComponent implements OnInit {
         "unit": "in",
         "orientation": "landscape",
         "size": "letter",
+        "fontSize": 4,
+        "autofitTextSize": true,
         "theme": "light",
         "showSubtechniques": "expanded",
         "font": "sans-serif",
@@ -426,8 +428,17 @@ export class SvgExportComponent implements OnInit {
             .each(function() { self.verticalAlignCenter(this); })
     
         // set technique and sub-technique groups to the same font size
-        techniqueGroups.select("text").attr("font-size", minFontSize);
-        subtechniqueGroups.select("text").attr("font-size", minFontSize);
+        if (this.config.autofitTextSize) {
+            this.config.fontSize = minFontSize.toFixed(2)
+        }
+        if (this.config.autofitTextSize) {
+            techniqueGroups.select("text").attr("font-size", minFontSize)
+            subtechniqueGroups.select("text").attr("font-size", minFontSize)
+        }
+        else {
+            techniqueGroups.select("text").attr("font-size", this.config.fontSize)
+            subtechniqueGroups.select("text").attr("font-size", this.config.fontSize)
+        }
 
         // track the smallest optimal font size for tactics
         let minTacticFontSize = Infinity;

--- a/nav-app/src/app/svg-export/svg-export.component.ts
+++ b/nav-app/src/app/svg-export/svg-export.component.ts
@@ -28,7 +28,8 @@ export class SvgExportComponent implements OnInit {
         "orientation": "landscape",
         "size": "letter",
         "fontSize": 4,
-        "autofitTextSize": true,
+        "autofitText": true,
+        "maxTextSize": Infinity,
         "theme": "light",
         "showSubtechniques": "expanded",
         "font": "sans-serif",
@@ -428,10 +429,11 @@ export class SvgExportComponent implements OnInit {
             .each(function() { self.verticalAlignCenter(this); })
     
         // set technique and sub-technique groups to the same font size
-        if (this.config.autofitTextSize) {
+        this.config.maxTextSize = minFontSize
+        if (this.config.autofitText) {
             this.config.fontSize = minFontSize.toFixed(2)
         }
-        if (this.config.autofitTextSize) {
+        if (this.config.autofitText) {
             techniqueGroups.select("text").attr("font-size", minFontSize)
             subtechniqueGroups.select("text").attr("font-size", minFontSize)
         }
@@ -717,6 +719,9 @@ export class SvgExportComponent implements OnInit {
      */
     private findSize(self: any, words: string[], width: number, height: number, center: boolean, maxFontSize: number = 12): number {
         let padding = 4;
+        if (!this.config.autofitText) {
+            padding = 1
+        }
 
         // break into multiple lines
         let distance = Math.min(height, (maxFontSize + 3) * words.length)


### PR DESCRIPTION
Added the ability for users to set the font size of the SVG export. Changes include:

- New "auto-fit font size" button, which calculates the most visually appealing font size
- New font size input, which allows users to manually change the SVG font size
- Warning message if the font size is increased such that the text overflows outside of any of the cells

Resolves https://github.com/mitre-attack/attack-navigator/issues/484