### PR TITLE
Replace `is_js` library

### DIFF
--- a/nav-app/package-lock.json
+++ b/nav-app/package-lock.json
@@ -27,6 +27,7 @@
         "core-js": "^3.31.1",
         "d3": "^7.8.5",
         "d3-svg-legend": "^2.25.6",
+        "detect-browser": "^5.3.0",
         "file-saver": "^2.0.5",
         "load-json-file": "^7.0.1",
         "mathjs": "^12.4.2",
@@ -7707,6 +7708,11 @@
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
       }
+    },
+    "node_modules/detect-browser": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/detect-browser/-/detect-browser-5.3.0.tgz",
+      "integrity": "sha512-53rsFbGdwMwlF7qvCt0ypLM5V5/Mbl0szB7GPN8y9NCcbknYOeVVXdrXEq+90IwAfrrzt6Hd+u2E2ntakICU8w=="
     },
     "node_modules/detect-node": {
       "version": "2.1.0",

--- a/nav-app/package-lock.json
+++ b/nav-app/package-lock.json
@@ -28,7 +28,6 @@
         "d3": "^7.8.5",
         "d3-svg-legend": "^2.25.6",
         "file-saver": "^2.0.5",
-        "is_js": "^0.9.0",
         "load-json-file": "^7.0.1",
         "mathjs": "^12.4.2",
         "ngx-color-picker": "^16.0.0",
@@ -9472,11 +9471,6 @@
       "engines": {
         "node": ">= 10"
       }
-    },
-    "node_modules/is_js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-      "integrity": "sha512-8Y5EHSH+TonfUHX2g3pMJljdbGavg55q4jmHzghJCdqYDbdNROC8uw/YFQwIRCRqRJT1EY3pJefz+kglw+o7sg=="
     },
     "node_modules/is-arrayish": {
       "version": "0.2.1",

--- a/nav-app/package.json
+++ b/nav-app/package.json
@@ -35,7 +35,6 @@
     "d3": "^7.8.5",
     "d3-svg-legend": "^2.25.6",
     "file-saver": "^2.0.5",
-    "is_js": "^0.9.0",
     "load-json-file": "^7.0.1",
     "mathjs": "^12.4.2",
     "ngx-color-picker": "^16.0.0",

--- a/nav-app/package.json
+++ b/nav-app/package.json
@@ -34,6 +34,7 @@
     "core-js": "^3.31.1",
     "d3": "^7.8.5",
     "d3-svg-legend": "^2.25.6",
+    "detect-browser": "^5.3.0",
     "file-saver": "^2.0.5",
     "load-json-file": "^7.0.1",
     "mathjs": "^12.4.2",

--- a/nav-app/src/app/datatable/data-table.component.ts
+++ b/nav-app/src/app/datatable/data-table.component.ts
@@ -7,8 +7,8 @@ import { ViewModel } from '../classes';
 import { DomSanitizer } from '@angular/platform-browser';
 import { Subscription } from 'rxjs';
 import * as Excel from 'exceljs/dist/exceljs.min.js';
-import * as is from 'is_js';
 import tinycolor from 'tinycolor2';
+import { isIE } from '../utils/utils';
 
 @Component({
     selector: 'DataTable',
@@ -104,7 +104,7 @@ export class DataTableComponent implements AfterViewInit, OnDestroy {
      * @param filename save as filename
      */
     public saveBlob(blob, filename): void {
-        if (is.ie()) {
+        if (isIE()) {
             // internet explorer
             const nav = window.navigator as any;
             nav.msSaveOrOpenBlob(blob, filename);

--- a/nav-app/src/app/services/viewmodels.service.ts
+++ b/nav-app/src/app/services/viewmodels.service.ts
@@ -2,7 +2,7 @@ import { EventEmitter, Injectable, Output } from '@angular/core';
 import { Gradient, TechniqueVM, ViewModel } from '../classes';
 import { DataService } from './data.service';
 import { evaluate } from 'mathjs';
-import * as is from 'is_js';
+import { isBoolean, isNumber } from '../utils/utils';
 
 @Injectable({
     providedIn: 'root',
@@ -98,10 +98,10 @@ export class ViewModelsService {
 
                 // if it didn't except after this, it evaluated to a single result
                 console.debug('score expression evaluated to single result to be applied to all techniques');
-                if (is.boolean(result)) {
+                if (isBoolean(result)) {
                     // boolean to binary
                     result = result ? '1' : '0';
-                } else if (is.not.number(result)) {
+                } else if (!isNumber(result)) {
                     // unexpected user input
                     throw Error('math result ( ' + result + ' ) is not a number');
                 }
@@ -139,10 +139,10 @@ export class ViewModelsService {
                     // did at least one technique have a score for this technique?
                     if (misses < scoreVariables.size) {
                         let mathResult = evaluate(opSettings.scoreExpression, scope);
-                        if (is.boolean(mathResult)) {
+                        if (isBoolean(mathResult)) {
                             // boolean to binary
                             mathResult = mathResult ? '1' : '0';
-                        } else if (is.not.number(mathResult)) {
+                        } else if (!isNumber(mathResult)) {
                             // unexpected user input
                             throw Error('math result ( ' + mathResult + ' ) is not a number');
                         }

--- a/nav-app/src/app/svg-export/svg-export.component.ts
+++ b/nav-app/src/app/svg-export/svg-export.component.ts
@@ -5,7 +5,7 @@ import { ConfigService } from '../services/config.service';
 import { DataService } from '../services/data.service';
 import { RenderableMatrix, RenderableTactic, RenderableTechnique } from './renderable-objects';
 import tinycolor from 'tinycolor2';
-import * as is from 'is_js';
+import { isIE } from '../utils/utils';
 declare var d3: any; //d3js
 
 @Component({
@@ -62,7 +62,7 @@ export class SvgExportComponent implements OnInit {
 
     // browser compatibility
     public get isIE(): boolean {
-        return is.ie();
+        return isIE();
     }
 
     // getters for visibility of SVG header sections

--- a/nav-app/src/app/tabs/tabs.component.spec.ts
+++ b/nav-app/src/app/tabs/tabs.component.spec.ts
@@ -11,7 +11,6 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { ConfigService } from "../services/config.service";
 import * as MockData from '../../tests/utils/mock-data';
 import * as MockLayers from '../../tests/utils/mock-layers';
-import * as is from 'is_js';
 import { of } from "rxjs";
 import { ChangelogComponent } from "../changelog/changelog.component";
 import { HelpComponent } from "../help/help.component";

--- a/nav-app/src/app/tabs/tabs.component.spec.ts
+++ b/nav-app/src/app/tabs/tabs.component.spec.ts
@@ -11,6 +11,7 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { ConfigService } from "../services/config.service";
 import * as MockData from '../../tests/utils/mock-data';
 import * as MockLayers from '../../tests/utils/mock-layers';
+import * as utils from '../utils/utils';
 import { of } from "rxjs";
 import { ChangelogComponent } from "../changelog/changelog.component";
 import { HelpComponent } from "../help/help.component";
@@ -94,14 +95,14 @@ describe('TabsComponent', () => {
 
     describe('ngAfterViewInit', () => {
         it('should open Safari warning for Safari version <= 13', () => {
-            spyOn(is, 'safari').withArgs('<=13').and.returnValue(true);
+            spyOn(utils, 'isSafari').withArgs('<=13').and.returnValue(true);
             let dialogSpy = spyOn(dialog, 'open');
             component.ngAfterViewInit();
             expect(dialogSpy).toHaveBeenCalled();
         });
 
         it('should not open Safari warning for Safari version > 13 or non-Safari browsers', () => {
-            spyOn(is, 'safari').withArgs('<=13').and.returnValue(false);
+            spyOn(utils, 'isSafari').withArgs('<=13').and.returnValue(false);
             let dialogSpy = spyOn(dialog, 'open');
             component.ngAfterViewInit();
             expect(dialogSpy).not.toHaveBeenCalled();

--- a/nav-app/src/app/tabs/tabs.component.spec.ts
+++ b/nav-app/src/app/tabs/tabs.component.spec.ts
@@ -11,7 +11,6 @@ import { MatTabsModule } from "@angular/material/tabs";
 import { ConfigService } from "../services/config.service";
 import * as MockData from '../../tests/utils/mock-data';
 import * as MockLayers from '../../tests/utils/mock-layers';
-import * as utils from '../utils/utils';
 import { of } from "rxjs";
 import { ChangelogComponent } from "../changelog/changelog.component";
 import { HelpComponent } from "../help/help.component";

--- a/nav-app/src/app/tabs/tabs.component.spec.ts
+++ b/nav-app/src/app/tabs/tabs.component.spec.ts
@@ -93,22 +93,6 @@ describe('TabsComponent', () => {
         });
     });
 
-    describe('ngAfterViewInit', () => {
-        it('should open Safari warning for Safari version <= 13', () => {
-            spyOn(utils, 'isSafari').withArgs('<=13').and.returnValue(true);
-            let dialogSpy = spyOn(dialog, 'open');
-            component.ngAfterViewInit();
-            expect(dialogSpy).toHaveBeenCalled();
-        });
-
-        it('should not open Safari warning for Safari version > 13 or non-Safari browsers', () => {
-            spyOn(utils, 'isSafari').withArgs('<=13').and.returnValue(false);
-            let dialogSpy = spyOn(dialog, 'open');
-            component.ngAfterViewInit();
-            expect(dialogSpy).not.toHaveBeenCalled();
-        });
-    });
-
     describe('loadTabs', () => {
         it('should load bundle when all fragment values are provided', async () => {
             let bundleURL = 'testbundleurl';

--- a/nav-app/src/app/tabs/tabs.component.ts
+++ b/nav-app/src/app/tabs/tabs.component.ts
@@ -11,9 +11,9 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { HttpClient } from '@angular/common/http';
 import { ChangelogComponent } from '../changelog/changelog.component';
 import { Subscription, forkJoin } from 'rxjs';
-import * as is from 'is_js';
 import * as globals from '../utils/globals';
 import { LayerInformationComponent } from '../layer-information/layer-information.component';
+import { isSafari } from '../utils/utils';
 
 @Component({
     selector: 'tabs',
@@ -94,7 +94,7 @@ export class TabsComponent implements AfterViewInit {
     }
 
     ngAfterViewInit(): void {
-        if (is.safari('<=13')) {
+        if (isSafari('<=13')) {
             // open safari version incompatibility warning
             this.safariDialogRef = this.dialog.open(this.safariWarning, {
                 width: '350px',

--- a/nav-app/src/app/utils/utils.ts
+++ b/nav-app/src/app/utils/utils.ts
@@ -1,0 +1,34 @@
+// utils.ts
+let comparatorFn = {
+	'<': function(a, b) { return a < b; },
+	'<=': function(a, b) { return a <= b; },
+	'>': function(a, b) { return a > b; },
+	'>=': function(a, b) { return a >= b; }
+};
+
+export function isBoolean(value: any): boolean {
+	return typeof value === 'boolean';
+}
+
+export function isNumber(value: any): boolean {
+	return typeof value === 'number';
+}
+
+export function isIE(): boolean {
+	let userAgent = (window.navigator && window.navigator.userAgent || '').toLowerCase();
+	let match = userAgent.match(/(?:msie |trident.+?; rv:)(\d+)/);
+	return match !== null;
+}
+
+export function isSafari(compRange): boolean {
+	function compare(version, comp) {
+		let str = (comp + '');
+		let n = +(str.match(/\d+/) || NaN);
+		let op = str.match(/^[<>]=?|/)[0];
+		return comparatorFn[op] ? comparatorFn[op](version, n) : (version == n || n !== n);
+	}
+
+	let userAgent = (window.navigator && window.navigator.userAgent || '').toLowerCase();
+	var match = userAgent.match(/version\/(\d+).+?safari/);
+	return match !== null && compare(match[1], compRange);
+}

--- a/nav-app/src/app/utils/utils.ts
+++ b/nav-app/src/app/utils/utils.ts
@@ -25,7 +25,7 @@ export function isSafari(compRange): boolean {
 	function compare(version, comp) {
 		let str = (comp + '');
 		let n = +(/\d+/.exec(str) || NaN);
-		let op = /^[<>]=?|/.exec(str)[0];
+		let op = /^[<>]=?/.exec(str)[0];
 		return comparatorFn[op] ? comparatorFn[op](version, n) : (version == n || Number.isNaN(n));
 	}
 

--- a/nav-app/src/app/utils/utils.ts
+++ b/nav-app/src/app/utils/utils.ts
@@ -1,4 +1,6 @@
 // utils.ts
+import { detect } from "detect-browser";
+
 let comparatorFn = {
 	'<': function(a, b) { return a < b; },
 	'<=': function(a, b) { return a <= b; },
@@ -15,9 +17,8 @@ export function isNumber(value: any): boolean {
 }
 
 export function isIE(): boolean {
-	let userAgent = (window.navigator && window.navigator.userAgent || '').toLowerCase();
-	let match = userAgent.match(/(?:msie |trident.+?; rv:)(\d+)/);
-	return match !== null;
+	const browser = detect();
+	return browser.name == 'ie';
 }
 
 export function isSafari(compRange): boolean {
@@ -28,7 +29,6 @@ export function isSafari(compRange): boolean {
 		return comparatorFn[op] ? comparatorFn[op](version, n) : (version == n || n !== n);
 	}
 
-	let userAgent = (window.navigator && window.navigator.userAgent || '').toLowerCase();
-	var match = userAgent.match(/version\/(\d+).+?safari/);
-	return match !== null && compare(match[1], compRange);
+	const browser = detect();
+	return browser.name == 'safari' && compare(browser.version.split('.')[0], compRange);
 }

--- a/nav-app/src/app/utils/utils.ts
+++ b/nav-app/src/app/utils/utils.ts
@@ -24,9 +24,9 @@ export function isIE(): boolean {
 export function isSafari(compRange): boolean {
 	function compare(version, comp) {
 		let str = (comp + '');
-		let n = +(str.match(/\d+/) || NaN);
-		let op = str.match(/^[<>]=?|/)[0];
-		return comparatorFn[op] ? comparatorFn[op](version, n) : (version == n || n !== n);
+		let n = +(/\d+/.exec(str) || NaN);
+		let op = /^[<>]=?|/.exec(str)[0];
+		return comparatorFn[op] ? comparatorFn[op](version, n) : (version == n || Number.isNaN(n));
 	}
 
 	const browser = detect();


### PR DESCRIPTION
Replaces `is_js` which appears to be no longer maintained. See [`is_js` GitHub Advisory](https://github.com/advisories/GHSA-pvrw-g6fx-mcx2).