### PR TITLE
Update gradient.ts

### DIFF
--- a/nav-app/src/app/classes/gradient.ts
+++ b/nav-app/src/app/classes/gradient.ts
@@ -136,6 +136,7 @@ export class Gradient {
             return this.gradientRGB[0].toHexString();
         }
         let index = ((value - this.minValue) / (this.maxValue - this.minValue)) * 100;
+        index = index > 99? 99 : index; // prune value to the maximum possible index of the array
         return this.gradientRGB[Math.round(index)].toHexString();
     }
 }

--- a/nav-app/src/app/classes/gradient.ts
+++ b/nav-app/src/app/classes/gradient.ts
@@ -136,8 +136,8 @@ export class Gradient {
             return this.gradientRGB[0].toHexString();
         }
         let index = ((value - this.minValue) / (this.maxValue - this.minValue)) * 100;
-        index = index > 99? 99 : index; // prune value to the maximum possible index of the array
-        return this.gradientRGB[Math.round(index)].toHexString();
+        let indexRounded = Math.round(index) > this.gradientRGB.length - 1 ? this.gradientRGB.length - 1 : Math.round(index); // prune value to the maximum possible index of the array
+        return this.gradientRGB[indexRounded].toHexString();
     }
 }
 

--- a/nav-app/src/app/classes/gradient.ts
+++ b/nav-app/src/app/classes/gradient.ts
@@ -136,7 +136,7 @@ export class Gradient {
             return this.gradientRGB[0].toHexString();
         }
         let index = ((value - this.minValue) / (this.maxValue - this.minValue)) * 100;
-        let indexRounded = Math.round(index) > this.gradientRGB.length - 1 ? this.gradientRGB.length - 1 : Math.round(index); // prune value to the maximum possible index of the array
+        let indexRounded = Math.min(Math.round(index), this.gradientRGB.length - 1); // prune value to the maximum possible index of the array
         return this.gradientRGB[indexRounded].toHexString();
     }
 }


### PR DESCRIPTION
Prune value to the maximum possible index of the gradientRGB array.

This is solving the following bug with a Math.round(r) value = 100 creating an array out of bounds exception:

<img width="807" height="409" alt="image" src="https://github.com/user-attachments/assets/95b3163a-6542-4e7c-b689-0bf0f5f6bca4" />

<img width="913" height="285" alt="image" src="https://github.com/user-attachments/assets/091c6e2b-58cb-47e9-95f9-ce5692451d0c" />
