### PR TITLE
Add support for new detections schema

### DIFF
--- a/nav-app/src/app/classes/domain.ts
+++ b/nav-app/src/app/classes/domain.ts
@@ -1,15 +1,6 @@
 import { ServiceAuth } from '../services/data.service';
-import { Campaign } from './stix/campaign';
-import { DataComponent } from './stix/data-component';
-import { Group } from './stix/group';
-import { Matrix } from './stix/matrix';
-import { Mitigation } from './stix/mitigation';
-import { Note } from './stix/note';
-import { Software } from './stix/software';
-import { Tactic } from './stix/tactic';
-import { Technique } from './stix/technique';
 import { Version } from './version';
-import { Asset } from './stix/asset';
+import { Asset, Campaign, DataComponent, DetectionStrategy, Group, Matrix, Mitigation, Note, Software, Tactic, Technique } from './stix';
 
 export class Domain {
     public readonly id: string; // domain ID
@@ -43,8 +34,10 @@ export class Domain {
     public assets: Asset[] = [];
     public dataComponents: DataComponent[] = [];
     public dataSources = new Map<string, { name: string; external_references: any[] }>(); // Map data source ID to name and urls to be used by data components
+    public dataComponentsToTechniques = new Map<string, Technique[]>(); // Map data component ID to list of related Techniques
     public groups: Group[] = [];
     public mitigations: Mitigation[] = [];
+    public detectionStrategies: DetectionStrategy[] = [];
     public notes: Note[] = [];
     public relationships: any = {
         // subtechnique subtechnique-of technique
@@ -53,6 +46,9 @@ export class Domain {
         // data component related to technique
         // ID of data component to [] of technique IDs
         component_rel: new Map<string, string[]>(),
+        // detection strategy related to technique
+        // ID of detection strategy to [] of technique IDs
+        detection_strategies_detect: new Map<string, string[]>(),
         // group uses technique
         // ID of group to [] of technique IDs
         group_uses: new Map<string, string[]>(),
@@ -76,6 +72,10 @@ export class Domain {
         targeted_assets: new Map<string, string[]>(),
     };
 
+    public get supportsLegacyDataSources(): boolean {
+        return !!this.dataSources.size && !!this.relationships.component_rel.size;
+    }
+
     constructor(domain_identifier: string, name: string, version: Version, urls?: string[]) {
         this.id = `${domain_identifier}-${version.number}`;
         this.domain_identifier = domain_identifier;
@@ -95,5 +95,9 @@ export class Domain {
         for (let callback of this.dataLoadedCallbacks) {
             callback();
         }
+    }
+
+    public getTechniqueById(stixId: string): Technique {
+        return this.techniques.find(t => t.id === stixId) ?? null;
     }
 }

--- a/nav-app/src/app/classes/stix/detection-strategy.ts
+++ b/nav-app/src/app/classes/stix/detection-strategy.ts
@@ -1,0 +1,36 @@
+import { DataService } from 'src/app/services/data.service';
+import { StixObject } from './stix-object';
+
+export class DetectionStrategy extends StixObject {
+    public analyticRefs: string[] = [];
+
+    /**
+     * Creates an instance of DetectionStrategy.
+     * @param {any} stixSDO for the detection strategy
+     * @param {Technique[]} subtechniques occuring under the technique
+     */
+    constructor(stixSDO: any, dataService: DataService) {
+        super(stixSDO, dataService);
+        this.analyticRefs = stixSDO.x_mitre_analytic_refs ?? [];
+    }
+
+    /**
+     * Get techniques detected by this detection strategy
+     * @returns {string[]} technique IDs detected by this detection strategy
+     */
+    public detects(domainVersionID): string[] {
+        let rels = this.dataService.getDomain(domainVersionID).relationships.detection_strategies_detect;
+        if (rels.has(this.id)) {
+            return rels.get(this.id);
+        } else {
+            return [];
+        }
+    }
+
+    /**
+     * Get all techniques related to the detection strategy
+     */
+    public relatedTechniques(domainVersionID): string[] {
+        return this.detects(domainVersionID);
+    }
+}

--- a/nav-app/src/app/classes/stix/index.ts
+++ b/nav-app/src/app/classes/stix/index.ts
@@ -9,3 +9,4 @@ export { Software } from './software';
 export { Tactic } from './tactic';
 export { Technique } from './technique';
 export { Asset } from './asset';
+export { DetectionStrategy } from './detection-strategy';

--- a/nav-app/src/app/classes/stix/stix-object.ts
+++ b/nav-app/src/app/classes/stix/stix-object.ts
@@ -17,7 +17,7 @@ export abstract class StixObject {
         // Properties
         this.id = stixSDO.id;
         this.name = stixSDO.name;
-        this.description = stixSDO.description;
+        this.description = stixSDO?.description ?? "";
         this.created = stixSDO.created;
         this.modified = stixSDO.modified;
         this.revoked = stixSDO.revoked ? stixSDO.revoked : false;

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.html
@@ -109,7 +109,7 @@
             <mat-expansion-panel [expanded]="expandedPanels[4]" (click)="userClickedExpand = true">
                 <mat-expansion-panel-header>
                     <mat-panel-title>
-                        <h4>Data Sources ({{ stixDataComponentLabels.length }})</h4>
+                        <h4>Data Components ({{ stixDataComponentLabels.length }})</h4>
                     </mat-panel-title>
                     <mat-panel-description></mat-panel-description>
                 </mat-expansion-panel-header>

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
@@ -249,15 +249,15 @@ export class SearchAndMultiselectComponent implements OnInit {
         }
 
         const legacyFormat = this.domain.supportsLegacyDataSources;
-        this.domain.dataComponents.forEach((c) => {
-            const source = legacyFormat ? c.source(this.viewModel.domainVersionID) : c;
-            const label = legacyFormat ? `${source.name}: ${c.name}` : source.name;
+        for (let dc of this.domain.dataComponents) {
+            const source = legacyFormat ? dc.source(this.viewModel.domainVersionID) : dc;
+            const label = legacyFormat ? `${source.name}: ${dc.name}` : source.name;
             const obj = {
-                objects: c.techniques(this.viewModel.domainVersionID),
+                objects: dc.techniques(this.viewModel.domainVersionID),
                 url: source.url,
             }
             this.stixDataComponents.set(label, obj);
-        });
+        }
         this.stixDataComponentLabels = this.filterAndSortLabels(Array.from(this.stixDataComponents.keys()), this._query);
     }
 

--- a/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
+++ b/nav-app/src/app/search-and-multiselect/search-and-multiselect.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, ViewEncapsulation } from '@angular/core';
-import { StixObject, Group, Mitigation, Software, Technique, Campaign, Asset } from '../classes/stix';
+import { StixObject, Group, Mitigation, Software, Technique, Campaign, Asset, DetectionStrategy } from '../classes/stix';
 import { ViewModelsService } from '../services/viewmodels.service';
 import { DataService } from '../services/data.service';
 import { ViewModel } from '../classes';
@@ -13,6 +13,7 @@ import { ViewModel } from '../classes';
 export class SearchAndMultiselectComponent implements OnInit {
     @Input() viewModel: ViewModel;
 
+    public domain;
     public stixTypes: any[] = [];
     public techniqueResults: Technique[] = [];
     // Data Components is a map mainly because it is a collection of labels that map to
@@ -25,15 +26,15 @@ export class SearchAndMultiselectComponent implements OnInit {
         0: true, // techniques panel
         1: false, // groups panel
         2: false, // software panel
-        3: false, // campaign panel
-        4: false, // mitigations panel
-        5: false, // data components panel
-        6: false, // assets panel
+        3: false, // mitigations panel
+        4: false, // campaigns panel
+        5: false, // assets panel
+        6: false, // data sources OR detection strategies panel
     };
 
     public fields = [
         {
-            label: 'name',
+            label: 'Name',
             field: 'name',
             enabled: true,
         },
@@ -43,13 +44,8 @@ export class SearchAndMultiselectComponent implements OnInit {
             enabled: true,
         },
         {
-            label: 'description',
+            label: 'Description',
             field: 'description',
-            enabled: true,
-        },
-        {
-            label: 'data sources',
-            field: 'datasources',
             enabled: true,
         },
     ];
@@ -92,6 +88,15 @@ export class SearchAndMultiselectComponent implements OnInit {
     }
 
     ngOnInit() {
+        this.domain = this.dataService.getDomain(this.viewModel.domainVersionID);
+        // backwards compatibility for old data sources
+        if (this.domain.supportsLegacyDataSources) {
+            this.fields.push({
+                label: 'Data Sources',
+                field: 'datasources',
+                enabled: true,
+            });
+        }
         this.getResults();
     }
 
@@ -202,8 +207,8 @@ export class SearchAndMultiselectComponent implements OnInit {
      * Retrieve master list of techniques and sub-techniques
      */
     public getTechniques(): void {
-        let allTechniques = this.dataService.getDomain(this.viewModel.domainVersionID).techniques;
-        for (let technique of allTechniques) {
+        let allTechniques = this.domain.techniques;
+        for (let technique of this.domain.techniques) {
             allTechniques = allTechniques.concat(technique.subtechniques);
         }
         this.techniqueResults = this.filterAndSort(allTechniques, this._query, true);
@@ -213,38 +218,44 @@ export class SearchAndMultiselectComponent implements OnInit {
      * Retrieve master list of STIX objects
      */
     public getStixData(): void {
-        let domain = this.dataService.getDomain(this.viewModel.domainVersionID);
-
         this.stixTypes = [
             {
                 label: 'threat groups',
-                objects: this.filterAndSort(domain.groups, this._query),
+                objects: this.filterAndSort(this.domain.groups, this._query),
             },
             {
                 label: 'software',
-                objects: this.filterAndSort(domain.software, this._query),
+                objects: this.filterAndSort(this.domain.software, this._query),
             },
             {
                 label: 'mitigations',
-                objects: this.filterAndSort(domain.mitigations, this._query),
+                objects: this.filterAndSort(this.domain.mitigations, this._query),
             },
             {
                 label: 'campaigns',
-                objects: this.filterAndSort(domain.campaigns, this._query),
+                objects: this.filterAndSort(this.domain.campaigns, this._query),
             },
             {
                 label: 'assets',
-                objects: this.filterAndSort(domain.assets, this._query),
+                objects: this.filterAndSort(this.domain.assets, this._query),
             },
         ];
 
-        domain.dataComponents.forEach((c) => {
-            const source = c.source(this.viewModel.domainVersionID);
-            const label = `${source.name}: ${c.name}`;
+        if (this.domain.detectionStrategies.length) {
+            this.stixTypes.push({
+                label: 'detection strategies',
+                objects: this.filterAndSort(this.domain.detectionStrategies, this._query),
+            })
+        }
+
+        const legacyFormat = this.domain.supportsLegacyDataSources;
+        this.domain.dataComponents.forEach((c) => {
+            const source = legacyFormat ? c.source(this.viewModel.domainVersionID) : c;
+            const label = legacyFormat ? `${source.name}: ${c.name}` : source.name;
             const obj = {
                 objects: c.techniques(this.viewModel.domainVersionID),
                 url: source.url,
-            };
+            }
             this.stixDataComponents.set(label, obj);
         });
         this.stixDataComponentLabels = this.filterAndSortLabels(Array.from(this.stixDataComponents.keys()), this._query);
@@ -323,22 +334,15 @@ export class SearchAndMultiselectComponent implements OnInit {
 
     public getRelated(stixObject: StixObject): Technique[] {
         // master list of all techniques and sub-techniques
-        let techniques = this.dataService.getDomain(this.viewModel.domainVersionID).techniques;
-        let allTechniques = techniques.concat(this.dataService.getDomain(this.viewModel.domainVersionID).subtechniques);
+        let techniques = this.domain.techniques;
+        let allTechniques = techniques.concat(this.domain.subtechniques);
         let domainVersionID = this.viewModel.domainVersionID;
 
-        if (stixObject instanceof Group) {
-            return allTechniques.filter((technique: Technique) => (stixObject as Group).relatedTechniques(domainVersionID).includes(technique.id));
-        } else if (stixObject instanceof Software) {
-            return allTechniques.filter((technique: Technique) => (stixObject as Software).relatedTechniques(domainVersionID).includes(technique.id));
-        } else if (stixObject instanceof Mitigation) {
-            return allTechniques.filter((technique: Technique) =>
-                (stixObject as Mitigation).relatedTechniques(domainVersionID).includes(technique.id)
-            );
-        } else if (stixObject instanceof Campaign) {
-            return allTechniques.filter((technique: Technique) => (stixObject as Campaign).relatedTechniques(domainVersionID).includes(technique.id));
-        } else if (stixObject instanceof Asset) {
-            return allTechniques.filter((technique: Technique) => (stixObject as Asset).relatedTechniques(domainVersionID).includes(technique.id));
+        const types = [Group, Software, Mitigation, Campaign, Asset, DetectionStrategy];
+        const matchedType = types.find(StixType => stixObject instanceof StixType);
+        if (matchedType) {
+            return allTechniques.filter((technique: Technique) => (stixObject as any).relatedTechniques(domainVersionID).includes(technique.id));
         }
+        return [];
     }
 }

--- a/nav-app/src/app/services/data.service.spec.ts
+++ b/nav-app/src/app/services/data.service.spec.ts
@@ -253,7 +253,7 @@ describe('DataService', () => {
             let relationships = domain.relationships;
             expect(relationships['campaign_uses'].size).toEqual(1);
             expect(relationships['campaigns_attributed_to'].size).toEqual(1);
-            expect(relationships['component_rel'].size).toEqual(2);
+            expect(relationships['component_rel'].size).toEqual(1);
             expect(relationships['group_uses'].size).toEqual(1);
             expect(relationships['mitigates'].size).toEqual(1);
             expect(relationships['revoked_by'].size).toEqual(1);

--- a/nav-app/src/app/services/data.service.spec.ts
+++ b/nav-app/src/app/services/data.service.spec.ts
@@ -421,24 +421,6 @@ describe('DataService', () => {
             expect(campaign_test.relatedTechniques('enterprise-attack-13')).toEqual([]);
         });
 
-        it('should test data components', () => {
-            let t1 = new Technique(MockData.T0000, [], mockService);
-            mockService.domains[0].techniques = [t1];
-            let data_component_test = new DataComponent(MockData.DC0000, mockService);
-            mockService.domains[0].dataSources.set(MockData.DC0000.id, {
-                name: MockData.stixSDO.name,
-                external_references: MockData.DC0000.external_references,
-            });
-            expect(data_component_test.source('enterprise-attack-13')).toEqual({ name: '', url: '' });
-            mockService.domains[0].dataSources.set(MockData.DS0000.id, {
-                name: MockData.stixSDO.name,
-                external_references: MockData.DC0001.external_references,
-            });
-            expect(data_component_test.source('enterprise-attack-13')).toEqual({ name: 'Name', url: 'test-url.com' });
-            mockService.domains[0].relationships['component_rel'].set('data-component-0', ['attack-pattern-0']);
-            expect(data_component_test.techniques('enterprise-attack-13')[0].id).toEqual('attack-pattern-0');
-        });
-
         it('should test group', () => {
             mockService.domains[0].relationships['group_uses'].set('intrusion-set-0', ['attack-pattern-0']);
             mockService.domains[0].relationships['campaign_uses'].set('intrusion-set-0', ['attack-pattern-0']);

--- a/nav-app/src/app/services/data.service.ts
+++ b/nav-app/src/app/services/data.service.ts
@@ -240,15 +240,19 @@ export class DataService {
                 let dataComponentRefs = analytic?.x_mitre_log_source_references?.map(
                     logSource => logSource.x_mitre_data_component_ref
                 ) ?? []; // handle optional field
-                for (let dataComponentRef of dataComponentRefs) {
-                    if (!domain.dataComponentsToTechniques.has(dataComponentRef)) {
-                        domain.dataComponentsToTechniques.set(dataComponentRef, []);
-                    }
-                    const techniqueList = domain.dataComponentsToTechniques.get(dataComponentRef);
-                    if (techniqueList.find(t => t.id === technique.id)) continue; // technique already added
-                    techniqueList.push(technique);
-                }
+                this.addTechniqueToDataComponents(domain, dataComponentRefs, technique);
             }
+        }
+    }
+
+    public addTechniqueToDataComponents(domain: Domain, dataComponentRefs: string[], technique: Technique) {
+        for (let dataComponentRef of dataComponentRefs) {
+            if (!domain.dataComponentsToTechniques.has(dataComponentRef)) {
+                domain.dataComponentsToTechniques.set(dataComponentRef, []);
+            }
+            const techniqueList = domain.dataComponentsToTechniques.get(dataComponentRef);
+            if (techniqueList.some(t => t.id === technique.id)) continue; // technique already added
+            techniqueList.push(technique);
         }
     }
 

--- a/nav-app/src/app/services/data.service.ts
+++ b/nav-app/src/app/services/data.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Buffer } from 'buffer';
 import { forkJoin, from, Observable } from 'rxjs';
-import { Asset, Campaign, DataComponent, Group, Software, Matrix, Technique, Mitigation, Note } from '../classes/stix';
+import { Asset, Campaign, DataComponent, Group, Software, Matrix, Technique, Mitigation, Note, DetectionStrategy } from '../classes/stix';
 import { TaxiiConnect, Collection } from '../utils/taxii2lib';
 import { Domain, Version, VersionChangelog } from '../classes';
 import { ConfigService } from './config.service';
@@ -65,6 +65,7 @@ export class DataService {
             let techniqueSDOs = [];
             let bundleMatrices = [];
             let idToTechniqueSDO = new Map<string, any>();
+            let analyticSDOs = [];
             // iterate through stix domain objects in the bundle
             for (let sdo of bundle.objects) {
                 // filter out duplicates, except for matrices
@@ -94,6 +95,12 @@ export class DataService {
                         break;
                     case 'x-mitre-asset':
                         domain.assets.push(new Asset(sdo, this));
+                        break;
+                    case 'x-mitre-detection-strategy':
+                        domain.detectionStrategies.push(new DetectionStrategy(sdo, this));
+                        break;
+                    case 'x-mitre-analytic':
+                        analyticSDOs.push(sdo);
                         break;
                     case 'course-of-action':
                         domain.mitigations.push(new Mitigation(sdo, this));
@@ -134,6 +141,11 @@ export class DataService {
 
             // parse platforms
             this.parsePlatforms(domain).forEach(platforms.add, platforms);
+
+            // build data component to techniques map
+            if (domain.detectionStrategies && analyticSDOs.length && domain.relationships.detection_strategies_detect) {
+                this.buildDataComponentToTechniquesMap(domain, analyticSDOs);
+            }
         }
 
         // create matrices
@@ -217,6 +229,29 @@ export class DataService {
         return platforms;
     }
 
+    public buildDataComponentToTechniquesMap(domain: Domain, analytics: any[]) {
+        for (let det of domain.detectionStrategies) {
+            let techniqueRefs = domain.relationships.detection_strategies_detect.get(det.id);
+            let techniqueRef = techniqueRefs.length > 0 ? techniqueRefs[0] : undefined; // should only be one
+            const technique = domain.getTechniqueById(techniqueRef);
+            if (!technique) continue; // no technique found, skip
+            for (let analytic_ref of det.analyticRefs) {
+                let analytic = analytics.find(an => an.id === analytic_ref);
+                let dataComponentRefs = analytic?.x_mitre_log_source_references?.map(
+                    logSource => logSource.x_mitre_data_component_ref
+                ) ?? []; // handle optional field
+                for (let dataComponentRef of dataComponentRefs) {
+                    if (!domain.dataComponentsToTechniques.has(dataComponentRef)) {
+                        domain.dataComponentsToTechniques.set(dataComponentRef, []);
+                    }
+                    const techniqueList = domain.dataComponentsToTechniques.get(dataComponentRef);
+                    if (techniqueList.find(t => t.id === technique.id)) continue; // technique already added
+                    techniqueList.push(technique);
+                }
+            }
+        }
+    }
+
     /**
      * Parses the given SRO into the domain relationship map
      * @param sro the SRO to parse
@@ -260,8 +295,14 @@ export class DataService {
                 domain.relationships['revoked_by'].set(sro.source_ref, sro.target_ref);
                 break;
             case 'detects':
-                // record data component: technique relationship
-                addRelationshipToMap(domain.relationships['component_rel'], sro.source_ref, sro.target_ref);
+                if (sro.source_ref.startsWith('x-mitre-data-component')) {
+                    // backwards compatibility for old data component detects techniques
+                    // record data component: technique relationship
+                    addRelationshipToMap(domain.relationships['component_rel'], sro.source_ref, sro.target_ref);
+                } else if (sro.source_ref.startsWith('x-mitre-detection-strategy')) {
+                    // record detection strategy: technique relationship
+                    addRelationshipToMap(domain.relationships['detection_strategies_detect'], sro.source_ref, sro.target_ref);
+                }
                 break;
             case 'attributed-to':
                 // record campaign:group relationship


### PR DESCRIPTION
Adds search & multiselect support for new detection strategy and modified data component schemas. Backwards compatibility for old data source/data component structure in previous versions of ATT&CK.