### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,6 @@ updates:
 
     groups:
       angular-ecosystem:
-        applies-to: "do I need to put something here"
         patterns:
           - "@angular*"
           - "rxjs"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
           - "rxjs"
           - "typescript"
           - "ngx-markdown"
+          - "marked" # peer of ngx-markdown, must update together
           - "ngx-drag-drop"
           - "ngx-color-picker"
         update-types:
@@ -28,4 +29,6 @@ updates:
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
       - dependency-name: "ngx-*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "marked"
         update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,5 +3,30 @@ updates:
   - package-ecosystem: "npm"
     directory: "nav-app"
     schedule:
-      interval: "weekly"
+      interval: "quarterly"
     target-branch: "develop"
+
+    groups:
+      angular-ecosystem:
+        applies-to: "do I need to put something here"
+        patterns:
+          - "@angular*"
+          - "rxjs"
+          - "typescript"
+          - "ngx-markdown"
+          - "ngx-drag-drop"
+          - "ngx-color-picker"
+        update-types:
+          - "minor"
+          - "patch"
+
+    ignore:
+      - dependency-name: "@angular*"
+        update-types: ["version-update:semver-major"]
+      # libraries constrained by angular version
+      - dependency-name: "rxjs"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "ngx-*"
+        update-types: ["version-update:semver-major"]

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "typescript"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/node"
+        update-types: ["version-update:semver-major"]
       - dependency-name: "ngx-*"
         update-types: ["version-update:semver-major"]
       - dependency-name: "marked"


### PR DESCRIPTION
Configure dependabot to ignore major updates for Angular and libraries constrained by Angular version to maintain compatibility.