### PR TITLE
ci: expand pull request quality gate with production build verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Jasmine Tests
+name: CI
 
 on:
   push:
@@ -7,7 +7,8 @@ on:
     branches: ["master", "develop"]
 
 jobs:
-  run-tests:
+  quality-gate:
+    name: Quality gate
     runs-on: ubuntu-latest
     defaults:
        run:
@@ -24,10 +25,13 @@ jobs:
         cache-dependency-path: nav-app/package-lock.json
     
     - name: Install
-      run: npm ci
+      run: npm ci --ignore-scripts
 
     - name: Run Jasmine tests
       run: npm run test -- --code-coverage --no-watch --browsers ChromeHeadlessCI
+
+    - name: Verify production build
+      run: npm run build -- --configuration production --aot=false
 
     - name: Archive code coverage results
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Rename the Jasmine-only workflow to the general CI workflow
- Rename the job to a broader quality gate
- Add a production build verification step after Jasmine tests

## Verification
- Not run locally; workflow change only