### PR TITLE
ci: run release workflows from version tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -3,7 +3,7 @@ name: Create Release
 on:
   push:
     tags:
-      - '*'
+      - 'v*.*.*'
 
 jobs:
   create_github_release:
@@ -11,6 +11,10 @@ jobs:
     permissions:
       contents: write
     steps:
+    - name: Validate release tag
+      run: |
+        [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+
     - uses: actions/checkout@v4
     - uses: ncipollo/release-action@v1
       with:

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -11,7 +11,9 @@ jobs:
     permissions:
       contents: write
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}
+      # Every release updates the same gh-pages branch, so serialize deployments
+      # across tags instead of allowing each tag to deploy concurrently.
+      group: ${{ github.workflow }}
     defaults:
       run:
         working-directory: ./nav-app/

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -2,7 +2,8 @@ name: GitHub Pages
 
 on:
   push:
-    branches: ["master"]
+    tags:
+      - 'v*.*.*'
 
 jobs:
   deploy-to-gh-pages:
@@ -17,6 +18,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Validate release tag
+        run: |
+          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
 
       - name: Use Node.js from .nvmrc
         uses: actions/setup-node@v4
@@ -58,7 +63,6 @@ jobs:
 
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.ref == 'refs/heads/master' }}
         with:
           deploy_key: ${{ secrets.DEPLOY_KEY }}
           publish_dir: ./nav-app/dist/browser

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -2,9 +2,6 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - 'master'
-      - 'develop'
     tags:
       - 'v*.*.*'
 
@@ -12,6 +9,10 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release tag
+        run: |
+          [[ "${GITHUB_REF_NAME}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]
+
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set Docker Image and Tags
@@ -21,10 +22,8 @@ jobs:
           images: |
             ghcr.io/mitre-attack/attack-navigator
           tags: |
-            # set latest tag for master branch
-            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'master') }}
-            # set develop tag for develop branch
-            type=ref,event=branch,enable=${{ github.ref == format('refs/heads/{0}', 'develop') }}
+            # set latest tag on release tag event
+            type=raw,value=latest
             # set semver tag (vX.Y.Z) on git tag event
             type=semver,pattern=v{{major}}.{{minor}}.{{patch}}
             # set git short commit as Docker tag (e.g., sha-ad132f5)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
          npm version major
          npm version minor
          npm version patch
+
     This will patch the version number appropriately and create the correct tag on the current commit.
+    Pushing a stable vX.Y.Z tag triggers the GitHub Release, GitHub Pages deployment, and Docker image publish workflows.
     The creation of the tag can be disabled with the --no-git-tag-version if desired.
 -->
 # 5.3.2 - 21 April 2026


### PR DESCRIPTION
## Summary

Update release-side GitHub Actions workflows so public release artifacts are produced from explicit stable version tags instead of ordinary branch pushes.

This changes:

- GitHub Pages deploys to run on stable `vX.Y.Z` tag pushes instead of `master` pushes
- GitHub Release creation to run only on stable `vX.Y.Z` tag pushes
- Docker image publishing to run only on stable `vX.Y.Z` tag pushes

Docker publishing still produces the release semver tag, `latest`, and `sha-*` tags. With this change, `latest` represents the latest tagged release image rather than the latest `master` branch push.

## Validation

Validated the trigger behavior on a fork before opening this PR:

- Branch pushes did not trigger release-side workflows
- A disposable `v*.*.*` tag triggered GitHub Pages, Create Release, and Docker Publish workflows
- Docker Publish was tested with a dry-run echo step on the fork to confirm trigger behavior without publishing an image

## Notes

- This PR intentionally does not include the existing `develop` CI quality-gate changes.
- GitHub Actions tag filters use glob matching, so each release workflow now validates `GITHUB_REF_NAME` before creating release artifacts.
